### PR TITLE
Revert "update go version"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go 1.x.y
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.14.6"
+          go-version: "^1.14.4"
 
       - name: Set $GOPATH and more variables
         run: |


### PR DESCRIPTION
This reverts commit d3c087814e81f8ccf8be5e2c7ce9432fccf897ce.

`ubuntu-latest` image in github-actions only has go `v1.14.4` as described in https://github.com/actions/virtual-environments/blob/ubuntu18/20200717.1/images/linux/Ubuntu1804-README.md

And `go-version: "^1.14.4"` will use the latest go v1.x.y in `ubuntu-latest` image automatically. There is no need to modify it.