### PR TITLE
Fix: inclusion file name not capitalized

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,10 +197,10 @@ func ParseList(list *List, ref map[string]*List) (*ParsedList, error) {
 		hasInclude := false
 		for _, entry := range entryList {
 			if entry.Type == "include" {
-				if pl.Inclusion[entry.Value] {
+				refName := strings.ToUpper(entry.Value)
+				if pl.Inclusion[refName] {
 					continue
 				}
-				refName := strings.ToUpper(entry.Value)
 				pl.Inclusion[refName] = true
 				r := ref[refName]
 				if r == nil {


### PR DESCRIPTION
To remove duplicate inclusion file in a list.
For example, `geolocation-!cn` includes `category-dev` and `npmjs`, and `category-dev` includes `npmjs`. Then `geolocation-!cn` will only include `npmjs` once.