### PR TITLE
geolocation-cn: remove Google domain

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -17,12 +17,6 @@ full:cdn.ampproject.org
 ## jsDelivr
 full:cdn.jsdelivr.net
 
-## Google
-recaptcha.net
-full:fonts.googleapis.com
-full:fonts.gstatic.com
-full:safebrowsing.googleapis.com
-
 ## 网宿科技
 ourdvsss.com
 

--- a/data/google
+++ b/data/google
@@ -11,6 +11,12 @@ include:polymer
 include:v8
 include:youtube
 
+# Available on China mainland
+recaptcha.net @cn
+full:fonts.googleapis.com @cn
+full:fonts.gstatic.com @cn
+full:safebrowsing.googleapis.com @cn
+
 # All .and domains
 and
 
@@ -446,7 +452,6 @@ publishproxy.com
 questvisual.com
 quickoffice.com
 quiksee.com
-recaptcha.net
 revolv.com
 ridepenguin.com
 run.app


### PR DESCRIPTION
google: Add attributes @cn to certain domain that available in China mainland

Ref: https://github.com/v2ray/domain-list-community/issues/487#issuecomment-664522925