### PR TITLE
data: clean duplicates domain

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -455,7 +455,6 @@ appleaustralia.net.au
 applebk.net
 applecarbon.com
 applecard.tv
-applecare.wang
 applecentar.co.rs
 applecentar.rs
 applecenter.cn @cn

--- a/data/bmw
+++ b/data/bmw
@@ -105,7 +105,6 @@ bmw-motorrad-motorsport.com
 bmw-motorrad-now-or-never.com
 bmw-motorrad-service-inclusive.com
 bmw-motorrad-test-ride.com
-bmw-motorrad.ec
 bmw-motorrad.at
 bmw-motorrad.be
 bmw-motorrad.bg

--- a/data/category-dev
+++ b/data/category-dev
@@ -45,7 +45,6 @@ include:js-org
 include:jsdelivr
 include:jupyter
 include:kali
-include:kotlin
 include:kubernetes
 include:linuxfromscratch
 include:linuxmint

--- a/data/category-media
+++ b/data/category-media
@@ -40,7 +40,6 @@ include:myradio
 include:newyorker
 include:nikkei
 include:now
-include:ntd
 include:nytimes
 include:passiontimes
 include:qmap

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -274,7 +274,6 @@ haidilao.com
 3h3.com
 3yx.com
 40407.com
-4paradigm.com
 500.com
 500d.me
 50bang.org
@@ -310,7 +309,6 @@ haidilao.com
 66wz.com
 68h5.com
 6rooms.com
-71.am
 714.com
 7230.com
 72byte.com
@@ -323,7 +321,6 @@ haidilao.com
 818ps.com
 84399.com
 885.com
-88cdn.com
 900.la
 917.com
 91danji.com
@@ -358,7 +355,6 @@ allyes.com
 anfensi.com
 anquan.org
 anruan.com
-antutu.com
 aotrip.net
 aoyou.com
 apk3.com
@@ -457,7 +453,6 @@ city8.com
 cjol.com
 clouddn.com
 cloudxns.com
-cn.bing.com
 cnanzhi.com
 cnbeta.com
 cnbetacdn.com
@@ -915,7 +910,6 @@ ottcn.com # 津ICP备12004891号-2
 oupeng.com
 p2peye.com
 p5w.net
-paipai.com
 paipaibang.com
 paopaoche.net
 pc6.com
@@ -1169,7 +1163,6 @@ xiaoxiongxitong.com
 xiaoyuxitong.com
 xiayx.com
 xiazaiba.com
-ximalaya.com
 xingjiesj.com
 xinhuanet.com
 xinrenxinshi.com
@@ -1182,7 +1175,6 @@ xiucai.com
 xiziwang.net
 xmhouse.com
 xnpic.com
-xoyo.com
 xpgod.com
 xsa239.com
 xuanchuanyi.com
@@ -1203,12 +1195,9 @@ yeepay.com
 yeshen.com
 yesky.com
 yh31.com
-yhd.com
 yicai.com
 yigao.com
 yigoonet.com
-yihaodian.com
-yihaodianimg.com
 yihedoors.com
 yikaochacha.com
 yikexue.com

--- a/data/jd
+++ b/data/jd
@@ -64,6 +64,7 @@ vg.com
 wangyin.com
 wdfok.com
 yhd.com
+yihaodian.com
 yihaodianimg.com
 yiyaojd.com
 yizhitou.com

--- a/data/kotlin
+++ b/data/kotlin
@@ -1,1 +1,0 @@
-kotlinlang.org

--- a/data/mini
+++ b/data/mini
@@ -190,7 +190,6 @@ minispygear.com
 ministcatharines.ca
 ministeagathe.com
 ministjohns.ca
-ministjohns.ca
 minitakesthestates.com
 minitoronto.ca
 minitroisrivieres.ca

--- a/data/nike
+++ b/data/nike
@@ -48,7 +48,6 @@ nike.us
 nike.xn--hxt814e # nike.网店
 nike0594.com
 nike23.com
-nikeit.com
 nikeadidas.com
 nikeairhuarache.com
 nikeairmax.com

--- a/data/ntd
+++ b/data/ntd
@@ -1,2 +1,0 @@
-ntd.com
-ntdtv.com

--- a/data/oppo
+++ b/data/oppo
@@ -1,6 +1,5 @@
 coloros.com
 finzfin.com
-h2os.com
 heytap.com
 heytapcs.com
 heytapdownload.com

--- a/data/taylorfrancis
+++ b/data/taylorfrancis
@@ -1,5 +1,4 @@
 tandf.co.uk
 tandfonline.com
 taylorandfrancis.com
-taylorandfrancis.com
 taylorfrancis.com


### PR DESCRIPTION
data: clean duplicates domain
    
    Domain                  Exist In            Remove From
    71.am                   iqiyi               geolocation-cn
    88cdn.com               xunlei              geolocation-cn
    applecare.wang          apple               apple
    bmw-motorrad.ec         bmw                 bmw
    h2os.com                oneplus             oppo
    iciba.com               wps                 geolocation-cn
    idqqimg.com             tencent             geolocation-cn
    ijinshan.com            cheetahmobile       geolocation-cn
    kotlinlang.org          jetbrains           kotlin
    ministjohns.ca          mini                mini
    nikeit.com              nike                nike
    ntd.com                 epochmediagroup     ntd
    ntdtv.com               epochmediagroup     ntd
    paipai.com              jd                  geolocation-cn
    taylorandfrancis.com    taylorfrancis       taylorfrancis
    ximalaya.com            ximalaya            geolocation-cn
    xoyo.com                seasun              geolocation-cn
    yhd.com                 jd                  geolocation-cn
    yihaodianimg.com        jd                  geolocation-cn
    
    Extra:
    Domain                  Move To             From
    yihaodian.com           jd                  geolocation-cn
