### PR TITLE
Create bandwagonhost

### DIFF
--- a/data/bandwagonhost
+++ b/data/bandwagonhost
@@ -1,0 +1,4 @@
+bandwagonhost.com
+bwh1.net
+bwh8.net
+bwh88.net

--- a/data/category-companies
+++ b/data/category-companies
@@ -8,6 +8,7 @@ include:amd
 include:apple
 include:atlassian
 include:att
+include:bandwagonhost
 include:canon
 include:cisco
 include:cloudcone


### PR DESCRIPTION
Note:
bwh1.net
bwh8.net
bwh88.net
are the only three mirrors that were officially recognized