### PR TITLE
Add speedtest keyword to ookla-speedtest.

### DIFF
--- a/data/ookla-speedtest
+++ b/data/ookla-speedtest
@@ -5,6 +5,7 @@ ekahau.com
 ookla.com
 ooklaserver.net
 pingtest.net
+speedtest
 speedtest.co
 speedtest.net
 speedtestcustom.com


### PR DESCRIPTION
The number of possible server matches is unrealistic to try to match with, but it seems that during the test, partial files are downloaded from something like speedtest.closest-server.com.

From the README, it seems the line should read `keyword:speedtest` but I noticed no other keywords were prefaced with that, so I omitted it. Let me know if you want me to change it.