### PR TITLE
Create lenovo

### DIFF
--- a/data/lenovo
+++ b/data/lenovo
@@ -1,0 +1,6 @@
+lefile.cn
+lenovo.com
+lenovo.com.cn
+lenovovip.com.cn
+thinkcentre.cn
+thinkcentre.com.cn


### PR DESCRIPTION
先不要合并，目前还有两件事未完成，我需要大家的意见。

## 对于没有中国接入点但拥有 ICP 备案的中国企业 / 组织的域名，如何处理

当前六个域名中，除了 `lefile.cn` 和 `lenovovip.com` 意外，其他的解析完全没有中国 IP，以 lenovo.com 为例：

![image](https://user-images.githubusercontent.com/23559565/90458047-d9ae1b00-e12f-11ea-8076-cabd8f25baa9.png)

甚至是 `lenovo.com.cn`：

![image](https://user-images.githubusercontent.com/23559565/90458064-e763a080-e12f-11ea-88de-88b739ac2cf0.png)

这一情况同样发生在大疆无人机

## 属于组织但无法访问 / 不在使用的域名，是否包含？

例如 `联想.中国`，`联想.cn` 等域名的 whois 都表明它们属于 lenovo 公司，但没有迹象表明正在使用，也有可能仅仅是注册以防抢注。

因此需要大家的意见，我会在创建 PR 后更改为 draft

~~吐槽一波美帝良心想~~