### PR TITLE
add jikipedia into geolocation-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -199,6 +199,7 @@ include:chinaunicom
 # 在线工具书
 guoxuedashi.com
 guoxuemi.com
+jikipedia.com
 
 # 餐饮类
 haidilao.com


### PR DESCRIPTION
由于 jikipedia 页面及相关资源均在同一域名下，所以直接放到了 `geolocation-cn` 中