### PR TITLE
add ld246 to hacpai

### DIFF
--- a/data/hacpai
+++ b/data/hacpai
@@ -1,1 +1,2 @@
 hacpai.com
+ld246.com


### PR DESCRIPTION
[ld246.com](https://ld246.com/article/1599662780208) is new domain from hacpai.
