### PR TITLE
Remove atianqi.com from xiaomitv-ads

### DIFF
--- a/data/xiaomitv-ads
+++ b/data/xiaomitv-ads
@@ -10,6 +10,5 @@ adv.sec.intl.miui.com @ads
 misc.in.duokanbox.com @ads
 ad.hpplay.cn @ads
 adeng.hpplay.cn @ads
-atianqi.com @ads
 kuyun.com @ads
 umeng.com @ads


### PR DESCRIPTION
Fixes https://github.com/v2ray/domain-list-community/issues/664