### PR TITLE
[WIP] About contribution guideline and clean DLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ full:www.google.com
 
 > The following types of rules are **NOT** fully compatible with the ones that defined by user in V2Ray config file. Do **Not** copy and paste directly.
 
-* Comment begins with `#`. It may begin anywhere in the file. The content in the line after `#` is treated as comment and ignored in production.
-* Inclusion begins with `include:`, followed by the file name of an existing file in the same directory.
-* Subdomain begins with `domain:`, followed by a valid domain name. The prefix `domain:` may be omitted.
-* Keyword begins with `keyword:`, followed by a string.
-* Regular expression begins with `regexp:`, followed by a valid regular expression (per Golang's standard).
-* Full domain begins with `full:`, followed by a complete and valid domain name.
-* Domains (including `domain`, `keyword`, `regexp` and `full`) may have one or more attributes. Each attribute begins with `@` and followed by the name of the attribute.
+- Comment begins with `#`. It may begin anywhere in the file. The content in the line after `#` is treated as comment and ignored in production.
+- Inclusion begins with `include:`, followed by the file name of an existing file in the same directory.
+- Subdomain begins with `domain:`, followed by a valid domain name. The prefix `domain:` may be omitted.
+- Keyword begins with `keyword:`, followed by a string.
+- Regular expression begins with `regexp:`, followed by a valid regular expression (per Golang's standard).
+- Full domain begins with `full:`, followed by a complete and valid domain name.
+- Domains (including `domain`, `keyword`, `regexp` and `full`) may have one or more attributes. Each attribute begins with `@` and followed by the name of the attribute.
 
 ## How it works
 
@@ -123,7 +123,9 @@ Attribute is useful for sub-group of domains, especially for filtering purpose. 
 
 ## Contribution guideline
 
-* Fork this repo, make modifications to your own repo, file a PR.
-* Please begin with small size PRs, say modification in a single file.
-* A PR must be reviewed and approved by another member.
-* After a few successful PRs, you may apply for manager access to this repository.
+- Fork this repo, make modifications to your own repo, file a PR.
+- Please begin with small size PRs, say modification in a single file.
+- Do not create a new list file for company/organization have rules less than 5.
+- Run `sort * | uniq -dc` to check duplicate rules before commit. (Recommend)
+- A PR must be reviewed and approved by another member.
+- After a few successful PRs, you may apply for manager access to this repository.


### PR DESCRIPTION
## 注意

**WIP，请各位贡献者在此 PR 完成之前，不要按照以下内容对 DLC 进行修改编辑。**

## 关于包含过少规则的列表文件

<details>
<summary>以下是截止 16abfd4399b25f665f051ac337dfe9edec8e5fe4 所有列表文件行数的统计 (<code>wc -l * | sort -n</code>) :</summary>

```
    0 xueyuanjun
    1 0x0
    1 115
    1 1pondo
    1 3dm
    1 3type
    1 4paradigm
    1 91porn
    1 aaex
    1 accuweather
    1 acfun-ads
    1 adblock
    1 adblockplus
    1 adcolony-ads
    1 addtoany
    1 adjust-ads
    1 ahmia
    1 akasha
    1 ali213
    1 alpinelinux
    1 amazon-ads
    1 americasvoice
    1 amytele
    1 antutu
    1 aomedia
    1 apache
    1 appleinsider
    1 archive
    1 ark
    1 atom
    1 atypi
    1 avgle
    1 avn
    1 avsforum
    1 b3log
    1 badgen
    1 baicaonetwork
    1 bbgwatch
    1 beeg
    1 betterexplained
    1 bighead
    1 biliplus
    1 bitbank
    1 bitcoin
    1 bitfinex
    1 bitmex
    1 bitquick
    1 bitstamp
    1 bittrex
    1 bitwarden
    1 blinkload
    1 blubrry
    1 breitbart
    1 brilliant
    1 browserleaks
    1 btcbox
    1 bypasscensorship
    1 bytedance-ads
    1 caijinglengyan
    1 caixin
    1 caoliu
    1 castro
    1 cdnjs
    1 centos
    1 cex
    1 change
    1 chaturbate
    1 chinadecoding
    1 chinadigitaltimes
    1 chinapower
    1 chiphell
    1 chocolatey
    1 citizenlab
    1 clearbitjs-ads
    1 clojure
    1 cloudconvert
    1 cloudn
    1 cnki
    1 cnpmjs
    1 code
    1 codecademy
    1 coinbase
    1 conair
    1 cordcloud
    1 craigslist
    1 ctyun
    1 cup
    1 cuttly
    1 cygwin
    1 cython
    1 d100
    1 datfoundation
    1 democracyearth
    1 deno
    1 dgtle
    1 dmzj
    1 dogecoin
    1 doom9
    1 dw
    1 eff
    1 egghead
    1 electron
    1 elixir
    1 elrepo
    1 emogi-ads
    1 epicbrowser
    1 eporner
    1 erji
    1 erlang
    1 evernote
    1 fanhaodian
    1 faststone
    1 feedly
    1 ffmpeg
    1 ffprofile
    1 figma
    1 firefox
    1 fireside
    1 flurry-ads
    1 fontexplorer
    1 fontsinuse
    1 foundertype
    1 freebeacon
    1 freebsd
    1 freecodecamp
    1 freenet
    1 freenode
    1 fteproxy
    1 gamersky
    1 gcores
    1 geekpark
    1 gentoo
    1 geph
    1 getcomposer
    1 gfashion
    1 gfycat
    1 git
    1 gitee
    1 globalsecurity
    1 glyphs
    1 gnu
    1 gofundme
    1 gravatar
    1 greatfire
    1 growingio-ads
    1 guardianproject
    1 guokr
    1 hegre
    1 heytea
    1 hinet
    1 hk01
    1 hkcnews
    1 hongkongfp
    1 hotjar-ads
    1 hqporner
    1 huanghuagang
    1 hubblephone
    1 i2p
    1 ietf
    1 iina
    1 infrapedia
    1 inmediahk
    1 inner-active-ads
    1 inoreader
    1 internationalsaimoe
    1 ipfs
    1 ipip
    1 itu
    1 ius
    1 javbus
    1 javhd
    1 javlibrary
    1 jenkins
    1 jfengtime
    1 jinjiang
    1 jinrishici
    1 jitsi
    1 jiyukobo
    1 js-org
    1 jupyter
    1 kali
    1 kernel
    1 kindgirls
    1 kindle4rss
    1 knovel
    1 kraken
    1 landofhope
    1 laracasts
    1 leanplum-ads
    1 letsencrypt
    1 linotype
    1 linux
    1 linuxfromscratch
    1 linuxmint
    1 litv
    1 localpresshk
    1 lua
    1 macports
    1 macrumors
    1 manmanbuy
    1 mariadb
    1 masterclass
    1 maying
    1 megaphone
    1 miaopai
    1 miaopasi
    1 mingw
    1 miraheze
    1 mixpanel-ads
    1 mocha
    1 mocloudplus
    1 moov
    1 mopub-ads
    1 mpv
    1 mray
    1 muncloud
    1 mxplayer-ads
    1 mysql
    1 mzed
    1 netflav
    1 neuralink
    1 newrelic-ads
    1 newyorker
    1 nixos
    1 nodejs
    1 nodesource
    1 nordstrom
    1 notepad
    1 ntc
    1 ok
    1 okex
    1 onesignal-ads
    1 onionshare
    1 ookla-speedtest-ads
    1 ooni
    1 openai
    1 opencollective
    1 openresty
    1 openssl
    1 opensuse
    1 openvpn
    1 osdn
    1 overcast
    1 packagist
    1 passiontimes
    1 pastebin
    1 patreon
    1 paxful
    1 pcre
    1 phantomjs
    1 php
    1 pigav
    1 pincong
    1 pingpe
    1 pkoplink
    1 pornhd
    1 postgresql
    1 press
    1 privacytools
    1 psiphon
    1 pubmatic-ads
    1 qingtingfm
    1 qmap
    1 quantil
    1 raspberrypi
    1 raspbian
    1 realvision
    1 redtube
    1 remirepo
    1 renzhe
    1 reurl
    1 rfa
    1 rfi
    1 rixcloud
    1 rpmfusion
    1 r-project
    1 rsf
    1 rt
    1 rtings
    1 scientificlinux
    1 scoop
    1 segment-ads
    1 sensorsdata-ads
    1 sfacg
    1 shadowsocks
    1 sharethis
    1 shields
    1 shorturl
    1 shuziyimin
    1 sinoinsider
    1 sitepoint
    1 skillshare
    1 slashdot
    1 smpte
    1 solidot
    1 soundofhope
    1 spacex
    1 spankbang
    1 sqlite
    1 sspai
    1 ssplive
    1 ssrpass
    1 stage1st
    1 staticfile
    1 stcserver
    1 steemit
    1 stunnel
    1 sublimetext
    1 svp
    1 syosetu
    1 tappx-ads
    1 telex
    1 test-ipv6
    1 tgbus
    1 thenationalpulse
    1 theporndude
    1 thestandnews
    1 tidelift
    1 tinyurl
    1 tipdm
    1 torproject
    1 tribler
    1 trustwave
    1 tsquare
    1 tube8
    1 tumblr
    1 tunsafe
    1 twister
    1 typenetwork
    1 typography
    1 uberads-ads
    1 udacity
    1 un
    1 unpkg
    1 unwire
    1 uproxy
    1 vaginacontest
    1 vgtime
    1 videojs
    1 videolan
    1 vim
    1 vuvuzela
    1 w3c
    1 w3schools
    1 wanfang
    1 warroom
    1 washingtonpost
    1 webflow
    1 webtype
    1 wenzhao
    1 weverse
    1 who
    1 whonix
    1 wikihow
    1 wikileaks
    1 windy
    1 wireguard
    1 wireshark
    1 wteam-ads
    1 wto
    1 xart
    1 xdty
    1 xhamster-ads
    1 xingrz
    1 x-org
    1 xposed
    1 yande
    1 yarnpkg
    1 youporn
    1 zerohedge
    1 zeronet
    1 zhihuishu
    1 zoomingin
    1 zsh
    2 36kr
    2 5ch
    2 928plus
    2 acplay
    2 adguard
    2 afdian
    2 afp
    2 android
    2 ap
    2 apa
    2 applovin-ads
    2 archlinux
    2 artstation
    2 asproex
    2 asus
    2 bandcamp
    2 bitflyer
    2 bootstrap
    2 boslife
    2 boxun
    2 buymeacoffee
    2 cabletv
    2 category-collaborate-cn
    2 chinaso
    2 chinaz
    2 coding
    2 colorfulclouds
    2 contentful
    2 cowlevel
    2 csdn
    2 c-span
    2 cybertrust
    2 cylink
    2 dangdang
    2 dcard
    2 debian
    2 digitalocean
    2 doi
    2 dribbble
    2 duowan
    2 duyaoss
    2 easylist
    2 edx
    2 entermediadb
    2 entrust
    2 fastlane
    2 flatpak
    2 flutter
    2 fontawesome
    2 fonts
    2 forbes
    2 ganji
    2 gfw
    2 gitv
    2 globalvoices
    2 hacpai
    2 haveibeenpwned
    2 heyzo
    2 hiido-ads
    2 hitun
    2 hkedcity
    2 hkopentv
    2 hm
    2 homedepot
    2 huya
    2 imgix
    2 imgur
    2 isgd
    2 javwide
    2 jianshu
    2 jinshuju
    2 keep
    2 khanacademy
    2 kingkonglive
    2 kodi
    2 kuaikan
    2 kuaishou-ads
    2 kubernetes
    2 kugou
    2 lagou
    2 lantern
    2 lianjia
    2 liberapay
    2 lihkg
    2 linguee
    2 linkedin
    2 localbitcoins
    2 londonreal
    2 ltn
    2 mapbox
    2 matters
    2 medium
    2 mega
    2 meitu
    2 moji
    2 mongodb
    2 myfonts
    2 myradio
    2 netlify
    2 nginx
    2 nist
    2 notion
    2 npmjs
    2 op
    2 openwrt
    2 pagecdn
    2 paofuyun
    2 pocketcasts
    2 pocoiq-ads
    2 polymer
    2 polyv
    2 proquest
    2 qt
    2 reabble
    2 realtype
    2 rebrandly
    2 redis
    2 renren
    2 rthk
    2 ruby
    2 ruleoflaw
    2 scala
    2 sci
    2 sciencedirect
    2 scmp
    2 scoreland
    2 secom
    2 segmentfault
    2 shadowsockscom
    2 showtimeanytime
    2 smzdm
    2 snapcraft
    2 softether
    2 soundcloud
    2 squirrelvpn
    2 stackpath
    2 startpage
    2 streamable
    2 surflite
    2 tagtic-ads
    2 taomee
    2 taptap
    2 ted
    2 telekom
    2 theboringcompany
    2 theinitium
    2 tiancity
    2 translatewiki
    2 trello
    2 typekit
    2 ucloud
    2 udemy
    2 unity-ads
    2 v8
    2 vaptcha
    2 watchout
    2 wikidot
    2 wiwide
    2 wwe
    2 xda
    2 ximalaya
    2 xnxx
    2 xueqiu
    2 xvideos
    2 ycombinator
    2 youjizz
    2 yyets-ads
    2 zeplin
    2 zhihu
    2 ziroom
    2 zynga-ads
    3 4chan
    3 abema
    3 acer
    3 addthis
    3 aerogard
    3 agora
    3 amd
    3 anaconda
    3 apple-ads
    3 atom-data-ads
    3 bitly
    3 bitsquare
    3 blender
    3 bongacams
    3 booking
    3 cas
    3 clearasil
    3 coinone
    3 coolapk
    3 costco
    3 cowtransfer
    3 csis
    3 dart
    3 deviantart
    3 dmm
    3 docker
    3 douban
    3 eleme
    3 esri
    3 ethereum
    3 geetest
    3 gitbook
    3 haskell
    3 hcaptcha
    3 homebrew
    3 identrust
    3 imdb
    3 javfinder
    3 jquery
    3 ku6
    3 liepin
    3 livejasmin
    3 mafengwo
    3 mailru
    3 maocloud
    3 mogujie
    3 n3ro
    3 nexitally
    3 nikkei
    3 nypost
    3 ogury-ads
    3 oschina
    3 perl
    3 pinduoduo
    3 pptv
    3 purikonejp
    3 quip
    3 quora
    3 reuters
    3 scp
    3 signal
    3 sohu
    3 speedtest
    3 steamunlocked
    3 strikingly
    3 stripe
    3 sxl
    3 teambition
    3 thetype
    3 tor
    3 u17
    3 uber
    3 ubuntu
    3 udn
    3 v2ray
    3 vancl
    3 weiphone
    3 xueersi
    3 yahoo-ads
    3 youzan
    3 zaobao
    3 zoom
    3 zuoyebang
    4 apkpure
    4 archiveofourown
    4 asahi
    4 bahamut
    4 bandwagonhost
    4 bttzyw
    4 cambridge
    4 category-wiki-cn
    4 chinanews
    4 cloudcone
    4 cn
    4 cnbc
    4 coursera
    4 creativecommons
    4 deepin
    4 dlercloud
    4 emojipedia
    4 fedora
    4 hupu
    4 jetbrains
    4 jiemian
    4 jsdelivr
    4 justmysocks
    4 lanzou
    4 launchpad
    4 madshi
    4 mdn
    4 meizu
    4 messenger
    4 mojang
    4 morisawa
    4 nationalgeographic
    4 netease-ads
    4 newsmax
    4 nga
    4 pixiv
    4 pornhub
    4 protonmail
    4 python
    4 readthedocs
    4 rubychina
    4 rust
    4 sogou
    4 sourceforge
    4 ssrcloud
    4 supersonic-ads
    4 swift
    4 taboola
    4 taikang
    4 taylorfrancis
    4 unionpay
    4 unity
    4 wangsu
    4 wholefoodsmarket
    4 wix
    4 wjx
    4 yy
    4 zb
    5 51job
    5 75team
    5 abc
    5 atlassian
    5 bitauto
    5 buypass
    5 canonical
    5 cmb
    5 comodo
    5 dyna
    5 embedly
    5 fontshop
    5 godaddy
    5 guo
    5 hellofont
    5 imperialcollege
    5 java
    5 jfrog
    5 metart
    5 mihoyo
    5 now
    5 oan
    5 razer
    5 reddit
    5 sinopec
    5 sling
    5 springer
    5 suning
    5 target
    5 umeng-ads
    5 upai
    5 xunlei
    5 ynet
    6 acfun
    6 arphic
    6 attwatchtv
    6 bbc
    6 category-hospital-cn
    6 ctexcel
    6 disqus
    6 douyu
    6 ehentai
    6 espn
    6 flickr
    6 gemfury
    6 gitlab
    6 hainanairlines
    6 hanyi
    6 ifanr
    6 ikea
    6 jd-ads
    6 jwplayer
    6 le
    6 meadjohnson
    6 mit
    6 oneplus
    6 oreilly
    6 picsee
    6 playstation
    6 pubmatic
    6 rockstar
    6 roku
    6 seasun
    6 sectigo
    6 shopify
    6 snap
    6 thelinuxfoundation
    6 twitch
    6 yuanfudao
    7 9to5
    7 aljazeera
    7 binance
    7 bootcss
    7 category-bank-cn
    7 clarivate
    7 didi
    7 digicert
    7 familymart
    7 gannett
    7 hashicorp
    7 hunantv-ads
    7 icbc
    7 line
    7 meituan
    7 movefree
    7 nytimes
    7 openjsfoundation
    7 panasonic
    7 sb
    7 slack
    7 starbucks
    7 thesun
    7 woolite
    7 yunfanjiasu
    8 4399
    8 alibabacloud
    8 amp
    8 cheetahmobile
    8 chinatelecom
    8 chinaunicom
    8 cnn
    8 dell
    8 dingtalk
    8 farfetch
    8 fastly
    8 gigabyte
    8 golang
    8 kuaishou
    8 landian
    8 mucinex
    8 muji
    8 qiniu
    8 ruanmei
    8 tiktok
    8 tongcheng
    8 ubi
    8 wordpress
    8 xhamster
    9 category-scholar-cn
    9 cern
    9 dedao
    9 discord
    9 elsevier
    9 google-registry
    9 gucci
    9 huobi
    9 logitech
    9 lysol
    9 naver
    9 umeng
    9 vilavpn
    9 zeetv
   10 bethesda
   10 gog
   10 hbo
   10 huawei
   10 marvel
   10 niconico
   10 origin
   10 tesla
   10 tmtpost
   10 viu
   10 walmart
   11 category-mooc-cn
   11 lg
   11 mortein
   11 openstreetmap
   11 phoenix
   11 sf-express
   11 tex
   11 theguardian
   11 whatsapp
   11 xiaomi
   11 yuewen
   12 aliyun
   12 heroku
   12 kingsoft
   12 manorama
   12 netflix
   12 onedrive
   12 spotify
   12 vercel
   12 youku
   12 zdns
   13 dmm-ads
   13 dnspod
   13 iqiyi
   13 newscorp
   13 ookla-speedtest
   13 rarbg
   13 shopee
   13 sky
   13 zoho
   14 9news
   14 braveux
   14 brightcove
   14 garena
   14 juejin
   14 monotype
   14 sonypictures
   14 visualarts
   14 xiaomitv-ads
   15 bilibili
   15 boc
   15 category-games
   15 everbright
   15 letv-ads
   15 oracle
   15 telegram
   15 verizon
   15 yyets
   16 insider
   16 msn
   16 twitter
   16 vimeo
   16 voxmedia
   16 webex
   17 58tongcheng
   17 category-cas
   17 dailymail
   17 epicgames
   17 globalsign
   17 ibm
   17 iqiyi-ads
   17 oculus
   17 tld-cn
   18 github
   18 huffpost
   18 intel-dev
   18 jiguang
   18 samsung
   19 adidas
   19 calgoncarbon
   19 cloudflare
   19 dropbox
   19 fandom
   19 mozilla
   19 oppo
   19 wps
   20 chinamobile
   20 sohu-ads
   20 vk
   20 wikimedia
   21 apple-update
   21 category-orgs
   21 stackexchange
   21 uu-chat
   22 softbank
   23 westerndigital
   23 zee
   24 nbcuniversal
   24 sina
   24 tencent-ads
   25 category-cryptocurrency
   25 netease
   26 google-ads
   28 category-ads-all
   28 cbs
   28 xbox
   29 ctrip
   29 nurofen
   29 oup
   29 yandex
   30 mcdonalds
   30 steam
   31 enfa
   31 private
   31 swisssign
   33 bing
   33 strepsils
   33 verisign
   34 appledaily
   35 dettol
   36 miniso
   37 cctv
   38 bytedance
   39 salesforce
   40 airwick
   41 category-anticensorship
   41 category-vpnservices
   41 finish
   41 rb
   42 category-entertainment
   42 nvidia
   43 duckduckgo
   43 qualcomm
   44 baidu
   44 epochmediagroup
   45 facebook-dev
   45 tencent
   45 veet
   46 hulu
   46 youku-ads
   47 vanish
   47 voanews
   49 pinterest
   50 azure
   50 category-companies
   51 icloud
   53 itunes
   53 qihoo360
   53 riot
   54 blizzard
   55 bloomberg
   57 apple-dev
   58 microsoft-dev
   62 durex
   66 akamai
   70 ieee
   72 instagram
   72 jd
   73 blogspot
   73 canon
   74 google-scholar
   80 category-scholar-!cn
   83 sina-ads
   88 alibaba-ads
   90 bestbuy
   94 category-media
   96 sony
  100 disney
  106 bridgestone
  113 category-ads
  113 category-dev
  113 cisco
  126 vmware
  135 adobe
  139 nintendo
  141 att
  154 baidu-ads
  160 hp
  166 alibaba
  166 visa
  169 yahoo
  174 category-porn
  174 youtube
  197 nike
  204 amazon
  206 mastercard
  215 volvo
  217 mini
  219 ea
  251 fox
  251 geolocation-!cn
  256 intel
  260 paypal
  293 microsoft
  377 ebay
  400 facebook
  525 bmw
  576 google
  715 beats
  872 apple
  896 tld-!cn
 1303 geolocation-cn
17282 total
```

</details>

单个列表文件所包含的规则条数分别为（仅记录了 ≤10 条的列表文件）：

```
0:  1
1:  373
2:  171
3:  83
4:  58
5:  33
6:  36
7:  25
8:  24
9:  14
10: 11
```

其中，单个列表文件中所包含的规则条数仅为 1 的列表多达 374 个。

> 注：为 0 的那一个是没有换行符导致 `wc -l` 计数出错。

这些仅包含 **1** 条规则的列表文件不但没有为 `geolocation-cn` 或其他 `categorys` 减轻维护负担，反而影响了维护。

单独为几条规则创建一个新的列表文件并不能有效减少 `geolocation-cn` 的规则条数，因为你还需要 `include: NAME`。

按照以上的统计信息，我建议所包含规则条数小于 **5** 的公司／组织不要为其创建单独的列表文件。

## 关于重复规则的处理

<details>
<summary>以下是截止 16abfd4399b25f665f051ac337dfe9edec8e5fe4 的重复规则 (<code>sort * | uniq -dc</code>) ：</summary>

```
2 # Advertisment & Analytics
2 att.tv
2 atttvnow.com
2 azuredigitaltwin.com
2 baidu
2 # CDN companies & Services
2 cnbc.com
2 cnbcfm.com
2 commandandconquer.com
2 dawngate.com
2 directv.com
3 # Domains and services below are available in China mainland
2 ebayclassifiedsgroup.com
2 # E-commerce
2 # Forums
2 full:hearthstone.nosdn.127.net @cn
2 icourse163.org
2 include:acfun-ads
2 include:addthis
2 include:alibaba-ads
2 include:alibabacloud
2 include:amazon-ads
2 include:android
2 include:apple-ads
2 include:apple-dev
2 include:atom
2 include:baidu-ads
2 include:cas
2 include:dart
2 include:eleme
2 include:facebook-dev
2 include:fastlane
2 include:flutter
2 include:fonts
2 include:gitee
2 include:github
2 include:golang
2 include:google-ads
2 include:google-scholar
2 include:intel-dev
2 include:iqiyi-ads
2 include:java
2 include:jd-ads
2 include:knovel
2 include:kuaishou-ads
2 include:line
2 include:microsoft-dev
2 include:netease-ads
2 include:ookla-speedtest-ads
2 include:playstation
2 include:polymer
2 include:pubmatic-ads
2 include:sina-ads
2 include:sonypictures
2 include:swift
2 include:taboola
2 include:tencent-ads
2 include:trello
2 include:umeng
2 include:umeng-ads
2 include:unity-ads
2 include:v8
2 include:videojs
2 include:wanfang
2 include:xbox
2 include:xhamster-ads
2 include:yahoo
2 include:yahoo-ads
2 include:yyets-ads
2 javlibrary.com
2 # Media & News & Press
2 mogucdn.com
2 mogu.com
2 mogujie.com
2 nbcuni.com
2 nekoxxx.com
2 nettyinternet.com
2 # Organizations
5 # Other
6 # Others
2 priceless.com
2 projectapex.com
2 pvzheroes.com
2 # Reference: https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains
3 # References:
2 rocksdb.org
2 # Services & Softwares
2 spearhead.kr
2 tiberiumalliances.com
2 visainfinite.ca
2 yuewen.com
```

</details>

> 注 1：以上内容，`include: NAME-ads` 可以忽略，因为他们被自己的公司／组织列表和 `category-ads` 所包含。\
> 注 2：以上内容，`# INFOMATION` 可以忽略，这些都是注释。

目前由于本项目缺乏 CI 自动检查重复规则，且贡献者有时没有检查自己所添加的规则是否已存在。

也有上述包含过少规则的列表文件的原因，规则零散的分布在各个列表文件，不便于检查。

导致时常会出现同一条规则被两个甚至多个列表文件所包含。

~~在此之前我已经清理过两次重复规则了。~~

在本项目拥有 CI 自动检查之前，建议各位贡献者在提交之前，运行一次：

```bash
sort * | uniq -dc
```

检查自己新添加的规则是否已存在于其他列表。

## 关于列表文件分级

目前的列表文件层次非常混乱，列表文件互相嵌套，非常不利于编辑和维护。

以这里给出的结构来分级:

![dlc](https://user-images.githubusercontent.com/3736910/97410858-88de4e00-193a-11eb-9ed1-ce9504af2d4d.png)

1. 分类列表：
   - 例如 `geolocation-cn` 或 `category-ads`。
   - 不可同级别互相 `include`。
   - 可以 `include` 二级列表。
   - 只能包含 `include` 规则且必须带上 `@attr` 属性。
2. 公司／组织列表：
   - 例如 `google` 或 `alibaba`。
   - 不可 `include` 任何列表。
   - **所有规则必须添加至少一个属性 `@attr`。**
   - 规则条数 > 5 的公司／组织可以拆分至单独的列表。
   - 规则条数 ≤ 5 的公司／组织统一添加至 `other`

**需要修改 `main.go` 以支持 `include:name@attr`。**

由于一条规则可以同时拥有多个 `@attr` 属性，这样分级可以充分利用 `@attr` 属性，同一公司／组织的规则不需要以分类拆分成多个列表文件。

> 例：`google`, `google-ads`, `google-scholar`

完全避免了列表文件中重复或嵌套的 `include`，大大减轻维护难度。

并且此更改不会影响到 `v2ray-core` 对 DLC 的使用。
