### PR TITLE
🗂 Remove cn attribute from cdn.office.net

### DIFF
--- a/data/microsoft
+++ b/data/microsoft
@@ -258,7 +258,6 @@ yammer.com
 
 # Domains and services below are available in China mainland
 # Use in config file like this: "geosite:microsoft@cn"
-cdn.office.net @cn
 dl.delivery.mp.microsoft.com @cn
 download.windowsupdate.com @cn
 full:bg.v4.a.dl.ws.microsoft.com @cn


### PR DESCRIPTION
My home network (China Telecom 163):

```
$ nslookup outlook-2.cdn.office.net
Server:		127.0.0.53
Address:	127.0.0.53#53

Non-authoritative answer:
outlook-2.cdn.office.net	canonical name = cdn-office.azureedge.net.
cdn-office.azureedge.net	canonical name = cdn-office.ec.azureedge.net.
cdn-office.ec.azureedge.net	canonical name = scdn1cc4b.wpc.9aea3.sigmacdn.net.
scdn1cc4b.wpc.9aea3.sigmacdn.net	canonical name = sni1gl.wpc.sigmacdn.net.
Name:	sni1gl.wpc.sigmacdn.net
Address: 152.199.39.108
Name:	sni1gl.wpc.sigmacdn.net
Address: 2606:2800:247:1cb7:261b:1f9c:2074:3c

$ ping outlook-2.cdn.office.net
PING outlook-2.cdn.office.net(2606:2800:247:1cb7:261b:1f9c:2074:3c (2606:2800:247:1cb7:261b:1f9c:2074:3c)) 56 data bytes
64 bytes from 2606:2800:247:1cb7:261b:1f9c:2074:3c (2606:2800:247:1cb7:261b:1f9c:2074:3c): icmp_seq=1 ttl=51 time=437 ms
64 bytes from 2606:2800:247:1cb7:261b:1f9c:2074:3c (2606:2800:247:1cb7:261b:1f9c:2074:3c): icmp_seq=2 ttl=51 time=442 ms
64 bytes from 2606:2800:247:1cb7:261b:1f9c:2074:3c (2606:2800:247:1cb7:261b:1f9c:2074:3c): icmp_seq=4 ttl=51 time=448 ms
64 bytes from 2606:2800:247:1cb7:261b:1f9c:2074:3c (2606:2800:247:1cb7:261b:1f9c:2074:3c): icmp_seq=6 ttl=51 time=438 ms
^C
--- outlook-2.cdn.office.net ping statistics ---
6 packets transmitted, 4 received, 33.3333% packet loss, time 5018ms
rtt min/avg/max/mdev = 437.398/441.330/447.794/4.156 ms

$ ping -4 outlook-2.cdn.office.net
PING  (152.199.39.108) 56(84) bytes of data.
64 bytes from 152.199.39.108 (152.199.39.108): icmp_seq=1 ttl=51 time=212 ms
64 bytes from 152.199.39.108 (152.199.39.108): icmp_seq=2 ttl=51 time=197 ms
64 bytes from 152.199.39.108 (152.199.39.108): icmp_seq=3 ttl=51 time=185 ms
64 bytes from 152.199.39.108 (152.199.39.108): icmp_seq=5 ttl=51 time=183 ms
^C64 bytes from 152.199.39.108: icmp_seq=6 ttl=51 time=195 ms

---  ping statistics ---
6 packets transmitted, 5 received, 16.6667% packet loss, time 6144ms
rtt min/avg/max/mdev = 182.678/194.335/211.912/10.404 ms
```

My friend's home network (China Unicom):

```
正在 Ping sni1gl.wpc.sigmacdn.net [152.199.39.108] 具有 32 字节的数据:
来自 152.199.39.108 的回复: 字节=32 时间=110ms TTL=51
来自 152.199.39.108 的回复: 字节=32 时间=116ms TTL=51
来自 152.199.39.108 的回复: 字节=32 时间=116ms TTL=51
来自 152.199.39.108 的回复: 字节=32 时间=117ms TTL=51

152.199.39.108 的 Ping 统计信息:
    数据包: 已发送 = 4，已接收 = 4，丢失 = 0 (0% 丢失)，
往返行程的估计时间(以毫秒为单位):
    最短 = 110ms，最长 = 117ms，平均 = 114ms
```