### PR TITLE
Modified category-dev and tld-!cn.

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -54,6 +54,10 @@ alpinelinux.org
 apache.org
 atom.io
 badgen.net
+
+# Bitvise official website.
+bitvise.com
+
 cdnjs.com
 centos.org
 chocolatey.org
@@ -71,6 +75,10 @@ gentoo.org
 getcomposer.org
 git-scm.com
 gnu.org
+
+# PuTTY and some software official websites.
+greenend.org.uk
+
 ius.io
 jenkins.io
 js.org
@@ -82,6 +90,10 @@ lua.org
 macports.org
 mariadb.org
 mingw.org
+
+# Mobatek official website.
+mobatek.net
+
 mysql.com
 nixos.org
 nodesource.com
@@ -94,6 +106,10 @@ packagist.org
 pcre.org
 phantomjs.org
 php.net
+
+# PuTTY unofficial website, owned by Bitvise.
+putty.org
+
 postgresql.org
 r-project.org
 raspberrypi.org
@@ -104,6 +120,10 @@ scoop.sh
 shields.io
 sqlite.org
 sublimetext.com
+
+# Termius official website.
+termius.com
+
 unpkg.com
 videojs.com
 videolan.org

--- a/data/tld-!cn
+++ b/data/tld-!cn
@@ -4,6 +4,10 @@
 
 # Used by U.S. federal government
 gov
+# Used by U.S. DoD.
+mil
+# Used by U.S. Higher Education.
+edu
 
 # ccTLD
 ac # Ascension Island


### PR DESCRIPTION
Add the domain names of Bitvise, PuTTY, Mobatek, Termius into `category-dev`.
```
bitvise.com
greenend.org.uk
mobatek.net
putty.org
termius.com
```

---

Add .mil, .edu TLD into `tld-!cn`
```
mil
edu
```