### PR TITLE
few Google Earth used domain is no longer available in China

### DIFF
--- a/data/google
+++ b/data/google
@@ -525,7 +525,6 @@ zukunftswerkstatt.de
 # Use in config file like this: "geosite:google@cn"
 full:csi-china.l.google.com @cn
 full:www.recaptcha.net @cn
-regexp:^khm([0-3]|db)?\.google(apis)?\.com$ @cn
 
 # The rules below are from https://github.com/felixonmars/dnsmasq-china-list/blob/master/google.china.conf
 full:265.com @cn

--- a/data/google
+++ b/data/google
@@ -524,7 +524,6 @@ zukunftswerkstatt.de
 # Domains and services below are available in China mainland
 # Use in config file like this: "geosite:google@cn"
 full:csi-china.l.google.com @cn
-full:kh.google.com @cn
 full:www.recaptcha.net @cn
 regexp:^khm([0-3]|db)?\.google(apis)?\.com$ @cn
 


### PR DESCRIPTION
Tested domain:
kh.google.com
khm0.google.com


Test result:
![1](https://user-images.githubusercontent.com/515763/108320972-772cf900-71fe-11eb-810e-4b87029dbf96.png)

![image](https://user-images.githubusercontent.com/515763/108325070-a6923480-7203-11eb-9aeb-2381bc6b3e4e.png)


ref: https://github.com/shadowsocks/shadowsocks-windows/issues/3103