### PR TITLE
Fix: create multiple level path

### DIFF
--- a/main.go
+++ b/main.go
@@ -329,7 +329,10 @@ func main() {
 
 	// Create output directory if not exist
 	if _, err := os.Stat(*outputDir); os.IsNotExist(err) {
-		os.Mkdir(*outputDir, 0755)
+		if mkErr := os.MkdirAll(*outputDir, 0755); mkErr != nil {
+			fmt.Println("Failed: ", mkErr)
+			os.Exit(1)
+		}
 	}
 
 	protoList := new(router.GeoSiteList)


### PR DESCRIPTION
`os.MkdirAll` is a better alternative method than `os.Mkdir` when creating multiple level path.