### PR TITLE
Add deepinos.org into geolocation-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -504,6 +504,7 @@ dcdkjx.com
 dd373.com
 ddooo.com
 dedecms.com
+deepinos.org
 develenv.com
 dginfo.com
 dgphospital.com


### PR DESCRIPTION
deepinos.org is an unofficial fourm of deepin linux distribution