### PR TITLE
Add gstaticadssl.l.google.com into google@cn

### DIFF
--- a/data/google
+++ b/data/google
@@ -552,6 +552,7 @@ full:doubleclick.net @cn
 full:firebase-settings.crashlytics.com @cn
 full:fonts.googleapis.com @cn
 full:fonts.gstatic.com @cn
+full:gstaticadssl.l.google.com @cn
 full:google-analytics.com @cn
 full:googleadservices.com @cn
 full:googleanalytics.com @cn

--- a/data/google
+++ b/data/google
@@ -524,6 +524,7 @@ zukunftswerkstatt.de
 # Domains and services below are available in China mainland
 # Use in config file like this: "geosite:google@cn"
 full:csi-china.l.google.com @cn
+full:gstaticadssl.l.google.com @cn
 full:www.recaptcha.net @cn
 
 # The rules below are from https://github.com/felixonmars/dnsmasq-china-list/blob/master/google.china.conf
@@ -552,7 +553,6 @@ full:doubleclick.net @cn
 full:firebase-settings.crashlytics.com @cn
 full:fonts.googleapis.com @cn
 full:fonts.gstatic.com @cn
-full:gstaticadssl.l.google.com @cn
 full:google-analytics.com @cn
 full:googleadservices.com @cn
 full:googleanalytics.com @cn


### PR DESCRIPTION
该域名是 `fonts.gstatic.com` 可能解析到的 CNAME 记录，且和众多 "gstatic" 域名一样，同时拥有国内和国外的 IP 地址，从不同区域的 DNS 服务器能解析到不同区域的 IP 地址。所以该域名应该符合 google@cn 的标准？

如果和 `fonts.gstatic.com` 不同步，其他软件使用 dlc 数据时可能引起类似 https://github.com/IrineSistiana/mosdns/discussions/112 的问题，代理亦产生怪异的现象如
![Screenshot_20210401_004445](https://user-images.githubusercontent.com/17105863/113193789-f3513c80-9292-11eb-833b-c55d65d25e19.png)
上：`curl fonts.gstatic.com`
下：`curl 172.217.5.195`

所以我建议使该域名和 `fonts.gstatic.com` 的匹配结果保持一致。