### PR TITLE
🍏 Remove `@cn` from `apps.apple.com`

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -797,7 +797,6 @@ full:adcdownload.apple.com.akadns.net @cn
 full:adcdownload.apple.com @cn
 full:appldnld.apple.com @cn
 full:appldnld.g.aaplimg.com @cn
-full:apps.apple.com @cn
 full:apps.mzstatic.com @cn
 full:cdn-cn1.apple-mapkit.com @cn
 full:cdn-cn2.apple-mapkit.com @cn


### PR DESCRIPTION
The Chinese CDN of `apps.apple.com` returns empty response on many apps. For example, you can try `curl https://apps.apple.com/us/app/leaf-lightweight-proxy/id1534109007` and compare the results.