### PR TITLE
📚 Remove `@cn` from `books.apple.com`

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -749,7 +749,6 @@ full:api-edge.apps.apple.com @cn
 full:apptrailers.itunes.apple.com @cn
 full:bag.itunes.apple.com @cn
 full:bookkeeper.itunes.apple.com @cn
-full:books.apple.com @cn
 full:client-api.itunes.apple.com @cn
 full:cma.itunes.apple.com @cn
 full:communities.apple.com @cn


### PR DESCRIPTION
Similar to #503, the Chinese CDN also returns 404 on books. For example, https://books.apple.com/us/book/uprooted/id887130411