### PR TITLE
add hellobike 8264.com

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -650,11 +650,11 @@ haote.com
 haoyouyinxiang.com
 hefei.cc
 heisha.net
+hellobike.com
+hello-inc.com
 henha.com
 henkuai.com
 herostart.com
-hellobike.com
-hello-inc.com
 hiido.com
 hitv.com
 hiyd.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -329,6 +329,7 @@ include:sinopec
 7x24cc.com
 7xdown.com
 818ps.com
+8264.com
 84399.com
 885.com
 900.la
@@ -652,6 +653,8 @@ heisha.net
 henha.com
 henkuai.com
 herostart.com
+hellobike.com
+hello-inc.com
 hiido.com
 hitv.com
 hiyd.com


### PR DESCRIPTION
增加Hellobike、8264户外网域名至中国区域名列表