### PR TITLE
Add curseforge, planetminecraft

### DIFF
--- a/data/category-games
+++ b/data/category-games
@@ -1,4 +1,5 @@
 include:blizzard
+include:curseforge
 include:ea
 include:epicgames
 include:garena
@@ -16,3 +17,4 @@ include:xbox
 
 fanatical.com
 humblebundle.com
+planetminecraft.com

--- a/data/curseforge
+++ b/data/curseforge
@@ -1,0 +1,2 @@
+curseforge.com
+forgecdn.net

--- a/data/planetminecraft
+++ b/data/planetminecraft
@@ -1,0 +1,1 @@
+planetminecraft.com

--- a/data/planetminecraft
+++ b/data/planetminecraft
@@ -1,1 +1,0 @@
-planetminecraft.com


### PR DESCRIPTION
These sites do not belong to Mojang, but may be useful for Minecraft mods players.