### PR TITLE
added `linetv`; updated `category-media`

### DIFF
--- a/data/category-media
+++ b/data/category-media
@@ -27,6 +27,7 @@ include:huffpost
 include:infowars
 include:insider
 include:kanzhongguo
+include:linetv
 include:londonreal
 include:ltn
 include:manorama
@@ -42,6 +43,7 @@ include:nikkei
 include:now
 include:nytimes
 include:oan
+include:primevideo
 include:realclear
 include:rthk
 include:scmp

--- a/data/line
+++ b/data/line
@@ -1,3 +1,5 @@
+include:linetv
+
 lin.ee
 line-apps-beta.com
 line-apps.com
@@ -11,5 +13,4 @@ linefriends.com
 linefriends.com.tw
 linegame.jp
 linemobile.com
-linetv.tw
 nhncorp.jp

--- a/data/linetv
+++ b/data/linetv
@@ -1,0 +1,1 @@
+linetv.tw


### PR DESCRIPTION
1. Although `linetv` seems to use a single domain currently, creating a separated field for it is still necessary for detailed routing.
2. Included `linetv` in `line` for forward compatibility
3. Added `linetv` and `primevideo` to `category-media`