### PR TITLE
Reproducible Builds: Sort protoList before marshal

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -371,6 +372,11 @@ func main() {
 			}
 		}
 	}
+
+	// Sort protoList so the marshaled list is reproducible
+	sort.SliceStable(protoList.Entry, func(i, j int) bool {
+		return protoList.Entry[i].CountryCode < protoList.Entry[j].CountryCode
+	})
 
 	protoBytes, err := proto.Marshal(protoList)
 	if err != nil {


### PR DESCRIPTION
hi!

This patch sorts the results before they're marshaled and written to disk. This seems to be sufficient to make dlc.dat reproducible, meaning building from the same git commit generates a file with an identical sha256sum.

This change makes the `v2ray-domain-list-community` Arch Linux package reproducible on our [reproducible builds system](https://reproducible.archlinux.org/).

## Before
```
% go run main.go
Use domain lists in ./data
dlc.dat has been generated successfully.
% sha256sum dlc.dat
e29639d1ac64774086a9fa7ab60f1b1acdbcf558d9724b9e430495fdb68e4624  dlc.dat
% go run main.go   
Use domain lists in ./data
dlc.dat has been generated successfully.
% sha256sum dlc.dat
18d2560fc752e9ef82545188a15fa5ea36815f2a0082582483169f68adcff704  dlc.dat
% 
```
## After
```
% go run main.go   
Use domain lists in ./data
dlc.dat has been generated successfully.
% sha256sum dlc.dat
dcea8ef9b4ba59c8355b194b072a81b9ca55db7df608b7849f7b6c7db4730ff6  dlc.dat
% go run main.go   
Use domain lists in ./data
dlc.dat has been generated successfully.
% sha256sum dlc.dat
dcea8ef9b4ba59c8355b194b072a81b9ca55db7df608b7849f7b6c7db4730ff6  dlc.dat
% 
```