### PR TITLE
Update mozilla

### DIFF
--- a/data/mozilla
+++ b/data/mozilla
@@ -2,6 +2,7 @@ include:firefox
 include:mdn
 include:rust
 
+mozilla.com
 mozilla.community
 mozilla.net
 mozilla.org


### PR DESCRIPTION
Add `domain: mozilla.com` used in Firefox account sync services to `mozilla`.