### PR TITLE
Moving blogger.com to blogspot list

### DIFF
--- a/data/blogspot
+++ b/data/blogspot
@@ -1,3 +1,7 @@
+# Main domain which weblogs are registered in
+blogger.com
+
+# Subdomains which weblogs can be accessed from
 blogspot.ae
 blogspot.al
 blogspot.am

--- a/data/blogspot
+++ b/data/blogspot
@@ -1,5 +1,6 @@
 # Main domain which weblogs are registered in
 blogger.com
+blogblog.com
 
 # Subdomains which weblogs can be accessed from
 blogspot.ae

--- a/data/google
+++ b/data/google
@@ -270,7 +270,6 @@ bazel.build
 bdn.dev
 beatthatquote.com
 blink.org
-blogblog.com
 brocaproject.com
 brotli.org
 bumpshare.com

--- a/data/google
+++ b/data/google
@@ -271,7 +271,6 @@ bdn.dev
 beatthatquote.com
 blink.org
 blogblog.com
-blogger.com
 brocaproject.com
 brotli.org
 bumpshare.com


### PR DESCRIPTION
`blogger.com` was moved from `google` list to `blogspot` list, which is itself a subcategory of `google`.