### PR TITLE
Update category-pt

### DIFF
--- a/data/category-pt
+++ b/data/category-pt
@@ -1,5 +1,5 @@
-bt.byr.cn
 bitpt.cn
+byr.pt
 ccfbits.org
 et8.org
 hdchina.org


### PR DESCRIPTION
byr no longer uses the original domain`bt.byr.cn`.