### PR TITLE
Add hackinn.com & okaapps.com

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -194,6 +194,7 @@ include:mpv
 include:netlify
 include:notion
 include:ok
+include:okaapps
 include:opencollective
 include:osdn
 include:pastebin

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -655,6 +655,7 @@ gzwanju.com
 h5uc.com
 hack520.com
 hackhome.com
+hackinn.com # 浙ICP备12044216号-3
 haishun.com
 hanboshi.com
 handanjob.com

--- a/data/okaapps
+++ b/data/okaapps
@@ -1,4 +1,4 @@
 domain:okaapps.com
 
 # CN part of okaapps
-regexp:(.+\.|^)zh\.okaapps\.com @cn
+regexp:^(.+\.)*zh\.okaapps\.com$ @cn

--- a/data/okaapps
+++ b/data/okaapps
@@ -1,0 +1,4 @@
+domain:okaapps.com
+
+# CN part of okaapps
+regexp:(.+\.|^)zh\.okaapps\.com @cn


### PR DESCRIPTION
These domains have been accepted with ICP Licensing.
- [hackinn.com](https://www.hackinn.com/)
- [data.hackinn.com](https://data.hackinn.com/)

[zh.okaapps.com](https://zh.okaapps.com) is assigned to Alicloud IP as well as `*.zh.okaapps.com`