### PR TITLE
Remove gfw.press from gfw

### DIFF
--- a/data/gfw
+++ b/data/gfw
@@ -1,2 +1,1 @@
-gfw.press
 gfw.report


### PR DESCRIPTION
gfw.press is an "airport" website