### PR TITLE
dslreports

### DIFF
--- a/data/casimages
+++ b/data/casimages
@@ -1,0 +1,1 @@
+casimages.com

--- a/data/dslreports
+++ b/data/dslreports
@@ -1,2 +1,3 @@
+broadbandreports.com
 dslr.net
 dslreports.com

--- a/data/dslreports
+++ b/data/dslreports
@@ -1,0 +1,2 @@
+dslr.net
+dslreports.com

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -113,6 +113,7 @@ include:category-entertainment
 
 # File & Image & Video hosting
 include:0x0
+include:casimages
 include:dropbox
 include:gfycat
 include:imagebam
@@ -122,6 +123,7 @@ include:imagetwist
 include:imgbb
 include:imgur
 include:pixhost
+include:postimages
 include:pstorage
 include:rumble
 include:streamable

--- a/data/postimages
+++ b/data/postimages
@@ -1,0 +1,2 @@
+postimages.org
+postimg.cc

--- a/data/speedtest
+++ b/data/speedtest
@@ -1,3 +1,4 @@
 # This tag 'speedtest' is for backward compatibility of 'geosite:speedtest' in V2Ray.
 
+include:dslreports
 include:ookla-speedtest


### PR DESCRIPTION
DSLReports rates and reviews cable, DSL and fiber optic internet services from ISPs. The site also runs support and discussion forums and offers online tools for testing internet connection