### PR TITLE
Updates on Cloudflare and several CAs

### DIFF
--- a/data/cloudflare
+++ b/data/cloudflare
@@ -15,6 +15,7 @@ cloudflarestream.com
 cloudflaretest.com
 cloudflarewarp.com
 one.one.one
+pacloudflare.com
 pages.dev
 trycloudflare.com
 videodelivery.net

--- a/data/comodo
+++ b/data/comodo
@@ -1,4 +1,5 @@
 comodo.com
+comodo.net
 comodoca.com
 comodoca2.com
 comodoca3.com

--- a/data/digicert
+++ b/data/digicert
@@ -1,3 +1,4 @@
+digicert-cn.com
 digicert.cn @cn
 digicert.com
 digitalcertvalidation.com

--- a/data/digicert
+++ b/data/digicert
@@ -1,3 +1,4 @@
+# It is worth noting that although its domain name contains the word cn, it does not actually resolve to servers located in mainland China.
 digicert-cn.com
 digicert.cn @cn
 digicert.com


### PR DESCRIPTION
- Added CNAME domain `pacloudflare.com` for Cloudflare Spectrum service.
- Added Comodo CA's `comodo.net`, which is reflected in the `AAA Certificate Services` certificate.
- Added DigiCert PKI domain `digicert-cn.com` powered by TrustAsia. It is worth noting that although its domain name contains the word `cn`, it does not actually resolve to servers located in mainland China.