### PR TITLE
add isvjcloud.com domain

### DIFF
--- a/data/jd
+++ b/data/jd
@@ -9,6 +9,7 @@ blackdragon.com
 caiyu.com
 chinabank.com.cn
 dao123.com
+isvjcloud.com
 jcloud-cdn.com
 jcloud-live.com
 jcloud-oss.com


### PR DESCRIPTION
该域名会在京东内频繁调用

isvjcloud.com——北京京东尚科信息技术有限公司

京东智联云是京东集团旗下的云计算综合服务提供商，拥有全球领先的云计算技术和完整的服务平台。依托京东集团在云计算、大数据、物联网和移动互联应用等多方面的长期业务实践和技术积淀，致力于打造社会化的云服务平台，向全社会提供安全、专业、稳定、便捷的云服务。