### PR TITLE
Update category-anticensorship

### DIFF
--- a/data/category-anticensorship
+++ b/data/category-anticensorship
@@ -20,7 +20,6 @@ fteproxy.org
 geti2p.net
 getoutline.org
 gfw.report
-greatfire.org
 guardianproject.info
 ipfs.io
 jitsi.org


### PR DESCRIPTION
`include:greatfire` has covered `greatfire.org`