### PR TITLE
Add pirate Chinese online novel sites that are blocked by GFW

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -7,6 +7,7 @@ include:attwatchtv
 include:bahamut
 include:bandcamp
 include:category-games
+include:category-novel
 include:dandanzan
 include:dazn
 include:deviantart

--- a/data/category-novel
+++ b/data/category-novel
@@ -1,0 +1,4 @@
+# This file contains domains of pirate chinese online novel sites that are blocked by GFW
+ptzwx.com
+quanben-xiaoshuo.com
+quanben.io


### PR DESCRIPTION
domains of pirate Chinese online novel sites that are blocked by GFW