### PR TITLE
Add Domain For Netflix Mobile Device Proxy Detect

### DIFF
--- a/data/netflix
+++ b/data/netflix
@@ -10,8 +10,8 @@ nflximg.net
 nflxsearch.net
 nflxso.net
 nflxvideo.net
-dualstack.apiproxy-
-dualstack.ichnaea-web-
+regexp:dualstack\.apiproxy-.*\.amazonaws\.com$
+regexp:dualstack\.ichnaea-web-.*\.amazonaws\.com$
 full:netflix.com.edgesuite.net
 
 # DNS test

--- a/data/netflix
+++ b/data/netflix
@@ -10,6 +10,9 @@ nflximg.net
 nflxsearch.net
 nflxso.net
 nflxvideo.net
+dualstack.apiproxy-
+dualstack.ichnaea-web-
+full:netflix.com.edgesuite.net
 
 # DNS test
 netflixdnstest1.com

--- a/data/netflix
+++ b/data/netflix
@@ -10,8 +10,6 @@ nflximg.net
 nflxsearch.net
 nflxso.net
 nflxvideo.net
-regexp:dualstack\.apiproxy-.*\.amazonaws\.com$
-regexp:dualstack\.ichnaea-web-.*\.amazonaws\.com$
 full:netflix.com.edgesuite.net
 
 # DNS test
@@ -25,3 +23,7 @@ netflixdnstest7.com
 netflixdnstest8.com
 netflixdnstest9.com
 netflixdnstest10.com
+
+＃regular expression
+regexp:(^|\.)dualstack\.apiproxy-.+\.amazonaws\.com$
+regexp:(^|\.)dualstack\.ichnaea-web-.+\.amazonaws\.com$


### PR DESCRIPTION
近期(去年了其实)Netflix在AWS美西增加了一组代理检测节点，URL地址如下：
https://dualstack.apiproxy-device-prod-nlb-*-********************.us-west-2.amazonaws.com
其中URL中有2组*号，第一组表示数字0-9（大概率为3，小概率为2），第二组为长度为16的十六进制字符串（有一定随机性）。

如果通过iOS/Android端升级后的app观看Netflix，且观看Netflix的线路中使用了分流，就会有一定概率会出现网络无法连接的提示。

很多代理分流规则中其实已经添加了这几条规则，今天看到这边的还没更新，故提交一下PR。