### PR TITLE
CA list update

### DIFF
--- a/data/actalis
+++ b/data/actalis
@@ -1,0 +1,2 @@
+actalis.com
+actalis.it

--- a/data/amazon
+++ b/data/amazon
@@ -1,4 +1,5 @@
 include:amazon-ads
+include:amazontrust
 include:aws
 include:imdb
 include:kindle
@@ -88,7 +89,6 @@ amazonpay.com
 amazonpay.in
 amazonsdi.com
 amazonstudiosguilds.com
-amazontrust.com
 amazonvideodirect.com
 amzn.asia
 amzn.com

--- a/data/amazontrust
+++ b/data/amazontrust
@@ -1,0 +1,2 @@
+amazontrust.com
+ss2.us

--- a/data/apple
+++ b/data/apple
@@ -1,5 +1,6 @@
 include:apple-ads
 include:apple-dev
+include:apple-pki
 include:beats
 include:icloud
 include:itunes
@@ -878,8 +879,6 @@ full:mesu-cdn.apple.com.akadns.net @cn
 full:mesu-china.apple.com.akadns.net @cn
 full:mesu.apple.com @cn
 full:music.apple.com @cn
-full:ocsp-lb.apple.com.akadns.net @cn
-full:ocsp.apple.com @cn
 full:oscdn.apple.com @cn
 full:oscdn.origin-apple.com.akadns.net @cn
 full:pancake.apple.com @cn

--- a/data/apple-pki
+++ b/data/apple-pki
@@ -1,0 +1,6 @@
+full:certs-lb.apple.com.akadns.net @cn
+full:certs.apple.com @cn
+full:crl-lb.apple.com.akadns.net @cn
+full:crl.apple.com @cn
+full:ocsp-lb.apple.com.akadns.net @cn
+full:ocsp.apple.com @cn

--- a/data/category-cas
+++ b/data/category-cas
@@ -1,17 +1,27 @@
 # This list contains well-known Certificate Authorities (CA) outside China mainland.
 
 # Reference: https://en.wikipedia.org/wiki/Certificate_authority
+include:actalis
+include:amazontrust
+include:apple-pki
 include:buypass
+include:certum
 include:comodo
 include:cybertrust
 include:digicert
 include:entrust
 include:globalsign
+include:godaddy
+include:google-trust-services
+include:hinet-eca
+include:hongkongpost
 include:identrust
 include:letsencrypt
 include:secom
 include:sectigo
+include:sslcom
 include:swisssign
 include:telekom
 include:trustwave
+include:twca
 include:verisign

--- a/data/certum
+++ b/data/certum
@@ -1,0 +1,2 @@
+certum.pl
+ocsp-certum.com

--- a/data/globalsign
+++ b/data/globalsign
@@ -1,3 +1,4 @@
+alphassl.com
 globalsign-media.com
 globalsign.be
 globalsign.ch
@@ -12,6 +13,8 @@ globalsign.fr
 globalsign.net
 globalsign.nl
 
-full:secure.globalsign.com @cn
+full:crl2.alphassl.com @cn
 full:ocsp.globalsign.com @cn
 full:ocsp2.globalsign.com @cn
+full:secure.globalsign.com @cn
+full:secure2.alphassl.com @cn

--- a/data/google
+++ b/data/google
@@ -8,6 +8,7 @@ include:golang
 include:google-ads
 include:google-registry
 include:google-scholar
+include:google-trust-services
 include:kaggle
 include:opensourceinsights
 include:polymer
@@ -551,7 +552,6 @@ full:clickserve.dartsearch.net @cn
 full:clientservices.googleapis.com @cn
 full:connectivitycheck.gstatic.com @cn
 full:corp.google.com @cn
-full:crl.pki.goog @cn
 full:csi.gstatic.com @cn
 full:dl.google.com @cn
 full:dl.l.google.com @cn
@@ -570,7 +570,6 @@ full:googletagservices.com @cn
 full:gstaticadssl.l.google.com @cn
 full:gtm.oasisfeng.com @cn
 full:imasdk.googleapis.com @cn
-full:ocsp.pki.goog @cn
 full:pagead-googlehosted.l.google.com @cn
 full:pki-goog.l.google.com @cn
 full:recaptcha.net @cn

--- a/data/google-trust-services
+++ b/data/google-trust-services
@@ -1,0 +1,4 @@
+pki.goog
+
+full:crl.pki.goog @cn
+full:ocsp.pki.goog @cn

--- a/data/hinet
+++ b/data/hinet
@@ -1,7 +1,7 @@
+include:hinet-eca
+
 cht.com.tw
 chtf.org.tw
 emome.net
 hinet.net
 xuite.net
-
-include:hinet-eca

--- a/data/hinet
+++ b/data/hinet
@@ -3,3 +3,5 @@ chtf.org.tw
 emome.net
 hinet.net
 xuite.net
+
+include:hinet-eca

--- a/data/hinet-eca
+++ b/data/hinet-eca
@@ -1,0 +1,4 @@
+full:eca.hinet.net
+full:gtlsca.nat.gov.tw
+full:ocsp.eca.hinet.net
+full:ocsp.gtlsca.nat.gov.tw

--- a/data/hongkongpost
+++ b/data/hongkongpost
@@ -1,0 +1,2 @@
+hongkongpost.gov.hk
+ecert.gov.hk

--- a/data/sectigo
+++ b/data/sectigo
@@ -4,4 +4,6 @@ instantssl.com
 optimumssl.com
 positivessl.com
 sectigo.com
+trust-provider.cn @cn
+trust-provider.com
 usertrust.com

--- a/data/sslcom
+++ b/data/sslcom
@@ -1,0 +1,2 @@
+ssl.com
+sslcom.cn @cn

--- a/data/twca
+++ b/data/twca
@@ -1,0 +1,1 @@
+twca.com.tw


### PR DESCRIPTION
Updated CA list with the following details:

1. Added the domain of Actalis;
2. Separate Amazon Trust Services;
3. Separated Apple PKI and adjusted its dedicated domains for AIA, CRL and OCSP;
4. Added Certum's domain and its OCSP domain;
5. Added the domain of AlphaSSL, a sub-brand of GlobalSign, and adjusted the domain dedicated to its CRL;
6. Separated Google Trust Services and adjusted the domain dedicated to its CRL and OCSP;
7. Added the domain of Chunghwa Telecom ECA and the domain of the National Development Committee GTLSCA operated by Chunghwa Telecom;
8. Added the domain of Hongkong Post;
9. Added the domain used by Sectigo for DCV and the domain specially provided for AIA, CRL and OCSP in mainland China;
10. Added the domain of SSL.com and its dedicated domain name for AIA, CRL and OCSP maintained by its agents in mainland China;
11. Added TWCA domain.

The CAs involved in this PR are all WebTrust certified and their root certificates are in the Mozilla repository, see https://ccadb-public.secure.force.com/mozilla/CACertificatesInFirefoxReport.