### PR TITLE
Add Microsoft PKI

### DIFF
--- a/data/category-cas
+++ b/data/category-cas
@@ -17,6 +17,7 @@ include:hinet-eca
 include:hongkongpost
 include:identrust
 include:letsencrypt
+include:microsoft-pki
 include:secom
 include:sectigo
 include:sslcom

--- a/data/microsoft
+++ b/data/microsoft
@@ -2,6 +2,7 @@ include:azure
 include:bing
 include:github
 include:microsoft-dev
+include:microsoft-pki
 include:msn
 include:onedrive
 include:xbox
@@ -185,7 +186,6 @@ msfteducation.ca
 msftnet.org
 msgamesresearch.com
 msocdn.com
-msocsp.com
 msturing.org
 msudalosti.com
 mymicrosoft.com
@@ -287,7 +287,6 @@ full:storeedgefd.dsx.mp.microsoft.com @cn
 full:wl.dlservice.microsoft.com @cn
 full:wscont1.apps.microsoft.com @cn
 full:wscont2.apps.microsoft.com @cn
-full:www.microsoft.com @cn
 full:xb.dlservice.microsoft.com @cn
 
 full:img-prod-cms-rt-microsoft-com.akamaized.net

--- a/data/microsoft-pki
+++ b/data/microsoft-pki
@@ -1,0 +1,7 @@
+msocsp.com
+
+full:crl.microsoft.com
+full:mscrl.microsoft.com
+full:ocsp.microsoft.com
+full:oneocsp.microsoft.com
+full:www.microsoft.com @cn


### PR DESCRIPTION
Separated the domain of Microsoft's own PKI.

Due to complex historical and practical factors, the domain `www.microsoft.com` is commonly used by Microsoft for AIA distribution and CRL distribution, and it also has a PKI repository, see https://www.microsoft.com/pki/mscorp/cps/default.htm and https://www.microsoft.com/pkiops/Docs/Repository.htm.