### PR TITLE
Update geolocation-!cn

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -146,7 +146,7 @@ include:category-porn
 include:falungong
 
 # Services & Softwares
-include: category-browser-!cn
+include:category-browser-!cn
 
 include:accuweather
 include:adblock


### PR DESCRIPTION
If you added a blank after the `include:` syntax, the workflow gets an error message.