### PR TITLE
Add AWS Global Accelerator Domain

### DIFF
--- a/data/aws
+++ b/data/aws
@@ -23,6 +23,7 @@ awsedstart.com
 awseducate.com
 awseducate.net
 awseducate.org
+awsglobalaccelerator.com
 awsloft-johannesburg.com
 awsloft-stockholm.com
 awssecworkshops.com


### PR DESCRIPTION
`awsglobalaccelerator.com` is the domain that AWS assigns to its Global Accelerator service.