### PR TITLE
Revert "Update category-ads"

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -111,9 +111,6 @@ regexp:^pinggai\d\.caixin\.com$
 adq.chinaso.com
 stat.chinaso.com
 
-# FireFox chinese version tracker
-sb.firefox.com.cn
-
 # Httpool
 toboads.com
 


### PR DESCRIPTION
Reverts v2fly/domain-list-community#1129

Turns out `sb.firefox.com.cn` is for providing safe browsing data. While users may think the Chinese provider is not doing great, completely blocking that site is not a good idea.
Refer to: https://bugzilla.mozilla.org/show_bug.cgi?id=1329860