### PR TITLE
itunes-apple.com.akadns.net remove full

### DIFF
--- a/data/itunes
+++ b/data/itunes
@@ -50,4 +50,4 @@ itunesu.net
 iutunes.com
 wwwitunes.com
 
-full:itunes-apple.com.akadns.net
+itunes-apple.com.akadns.net


### PR DESCRIPTION
Since apple have another sub-domain unber itunes-apple.com.akadns.net
example: xp.itunes-apple.com.akadns.net