### PR TITLE
Update test-pr.yml

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Upload Test-dlc.dat
         uses: actions/upload-artifact@v3
         with:
-          name: Test-dlc.dat
+          name: Test-${{ github.run_number }}-dlc.dat
           path: dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,10 +30,10 @@ jobs:
           cd code || exit 1
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
-          mv dlc.dat test-${{ github.run_number }}-dlc.dat
+          mv dlc.dat TEST-${{ github.run_number }}-dlc.dat
           
-      - name: Upload test-${{ github.run_number }}-dlc.dat
+      - name: Upload TEST-${{ github.run_number }}-dlc.dat
         uses: actions/upload-artifact@v3
         with:
-          name: test-${{ github.run_number }}-dlc.dat
-          path: test-${{ github.run_number }}-dlc.dat
+          name: TEST-${{ github.run_number }}-dlc.dat
+          path: TEST-${{ github.run_number }}-dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,9 +30,10 @@ jobs:
           cd code || exit 1
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
+          mv dlc.dat Test-${{ github.run_number }}-dlc.dat
           
       - name: Upload Test-${{ github.run_number }}-dlc.dat
         uses: actions/upload-artifact@v3
         with:
           name: Test-${{ github.run_number }}-dlc.dat
-          path: dlc.dat
+          path: Test-${{ github.run_number }}-dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,7 +31,7 @@ jobs:
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
           
-      - name: Upload Test-dlc.dat
+      - name: Upload Test-${{ github.run_number }}-dlc.dat
         uses: actions/upload-artifact@v3
         with:
           name: Test-${{ github.run_number }}-dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,7 +31,7 @@ jobs:
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
           
-      - name: Upload a Build Artifact
+      - name: Upload Test-dlc.dat
         uses: actions/upload-artifact@v3
         with:
           name: Test-dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,10 +30,10 @@ jobs:
           cd code || exit 1
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
-          mv dlc.dat Test-${{ github.run_number }}-dlc.dat
+          mv dlc.dat test-${{ github.run_number }}-dlc.dat
           
-      - name: Upload Test-${{ github.run_number }}-dlc.dat
+      - name: Upload test-${{ github.run_number }}-dlc.dat
         uses: actions/upload-artifact@v3
         with:
-          name: Test-${{ github.run_number }}-dlc.dat
-          path: Test-${{ github.run_number }}-dlc.dat
+          name: test-${{ github.run_number }}-dlc.dat
+          path: test-${{ github.run_number }}-dlc.dat

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,3 +30,9 @@ jobs:
           cd code || exit 1
           go run ./ --outputdir=../ --exportlists=category-ads-all,tld-cn,cn,tld-\!cn,geolocation-\!cn,apple,icloud
           cd ../ && rm -rf code
+          
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test-dlc.dat
+          path: dlc.dat


### PR DESCRIPTION
I think we can provide the file which has been generated to the contributor. It has two reasons. First, the contributor can get the file as soon as possible. At the same time, it will not influence other users before we merge it. Second, the contributor will test the part which has been changed by himself/herself. If he/she gets any exceptional problem, he/she can fix it before we find it. For example, in #997, the contributor finds the problem and returns it to us.