### PR TITLE
update hamivideo rules for apple tv

### DIFF
--- a/data/hamivideo
+++ b/data/hamivideo
@@ -4,3 +4,5 @@ full:mobilelive-hamivideo.cdn.hinet.net
 full:scc.ott.hinet.net
 full:static-hamivideo.cdn.hinet.net
 full:weblive-hamivideo.cdn.hinet.net
+full:pvr-hamivideo.cdn.hinet.net
+full:tvcastlive-hamivideo.cdn.hinet.net


### PR DESCRIPTION
抓包发现apple tv下的hamivideo客户端会使用pvr-hamivideo.cdn.hinet.net和tvcastlive-hamivideo.cdn.hinet.net这两个域名(应该是针对电视馆订阅，其他订阅未知)，如果不添加会无法播放电视直播。