### PR TITLE
Add starfieldtech

### DIFF
--- a/data/category-cas
+++ b/data/category-cas
@@ -21,6 +21,7 @@ include:microsoft-pki
 include:secom
 include:sectigo
 include:sslcom
+include:starfieldtech
 include:swisssign
 include:telekom
 include:trustwave

--- a/data/starfieldtech
+++ b/data/starfieldtech
@@ -1,0 +1,1 @@
+starfieldtech.com


### PR DESCRIPTION
[Starfield Technologies](https://www.starfieldtech.com/), a WebTrust certified CA whose G2 chain is operated by Amazon Trust Services.

ref https://certs.starfieldtech.com/repository/

Since it only sold part of the G2 chain, it is still a CA independent of Amazon Trust Services, so its domain is a new file.

