### PR TITLE
Update qualcomm

### DIFF
--- a/data/qualcomm
+++ b/data/qualcomm
@@ -1,18 +1,22 @@
 airgonetworks.com
 berkanawireless.com
+cdmatech.com
 dragoniscoming.com
 gobianywhere.com
+gpsonextra.net @cn
 hellosmartbook.com
 imod.com
 ipleadership.org
 iskoot.com
+izatcloud.net @cn
 meetsmartbook.com
 patenttruth.org
 pixtronix.com
+qceventscenter.com.cn @cn
 qctconnect.com
 qprize.com
 qualcomm-email.com
-qualcomm.cn
+qualcomm.cn @cn
 qualcomm.co.id
 qualcomm.co.in
 qualcomm.co.jp
@@ -36,6 +40,7 @@ snapdragonbooth.com
 uplinq.com
 wipower.com
 wirelessreach.com
+xtracloud.cn @cn
 
 # brew
 brewmp.com


### PR DESCRIPTION
高通企业管理（上海）有限公司
`izatcloud.net` 沪ICP备17015640号-3
`gpsonextra.net` 沪ICP备17015640号-1
`xtracloud.cn` 沪ICP备17015640号-6
`qceventscenter.com.cn` 沪ICP备17015640号-7

ICPed, but DNS record show that it is not in mainland China.
`cdmatech.com` 沪ICP备17015640号-2