### PR TITLE
Update aws

### DIFF
--- a/data/aws
+++ b/data/aws
@@ -19,11 +19,13 @@ amazonworkdocs.com.cn @cn
 amplifyapp.com
 amplifyframework.com
 asfiovnxocqpcry.com.cn @cn
+aws-border.cn @cn
+aws-icp-domain-manager.cn @cn
+aws-iot-hackathon.com
 awsapps.cn @cn
 awsapps.com.cn @cn
 awsautopilot.com
 awsautoscaling.com
-aws-border.cn @cn
 awsbraket.com
 awscommandlineinterface.com
 awsedstart.com
@@ -31,8 +33,6 @@ awseducate.com
 awseducate.net
 awseducate.org
 awsglobalaccelerator.com
-aws-icp-domain-manager.cn @cn
-aws-iot-hackathon.com
 awsloft-johannesburg.com
 awsloft-stockholm.com
 awssecworkshops.com
@@ -60,7 +60,7 @@ regexp:.+\.awsdns-[0-9][0-9]\.com$
 regexp:.+\.awsdns-[0-9][0-9]\.net$
 regexp:.+\.awsdns-[0-9][0-9]\.org$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.biz$
-regexp:.+\.awsdns-cn-[0-9][az-0-9]\.cn$
+regexp:.+\.awsdns-cn-[0-9][a-e0-9]\.cn$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.com$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.net$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.top$

--- a/data/aws
+++ b/data/aws
@@ -6,12 +6,12 @@ a2z.org.cn @cn
 acmvalidations.com
 acmvalidationsaws.com
 aesworkshops.com
+amazonaws-china.com
 amazonaws.cn @cn
 amazonaws.co.uk
 amazonaws.com
 amazonaws.com.cn @cn
 amazonaws.tv
-amazonaws-china.com
 amazonwebservices.com.cn @cn
 amazonworkdocs.cn @cn
 amazonworkdocs.com
@@ -40,10 +40,10 @@ awsstatic.cn @cn
 awsstatic.com
 awsthinkbox.com
 cdkworkshop.com
-cloudfront.cn @cn
-cloudfront.net
 cloudfront-cn.net @cn
 cloudfront-test.cn @cn
+cloudfront.cn @cn
+cloudfront.net
 containersonaws.com
 elasticbeanstalk.com
 nwcdcloud.cn @cn

--- a/data/aws
+++ b/data/aws
@@ -2,21 +2,28 @@
 aws
 
 # AWS
+a2z.org.cn @cn
 acmvalidations.com
 acmvalidationsaws.com
 aesworkshops.com
-amazonaws-china.com
+amazonaws.cn @cn
 amazonaws.co.uk
 amazonaws.com
+amazonaws.com.cn @cn
 amazonaws.tv
+amazonaws-china.com
+amazonwebservices.com.cn @cn
 amazonworkdocs.cn @cn
 amazonworkdocs.com
 amazonworkdocs.com.cn @cn
 amplifyapp.com
 amplifyframework.com
-aws-iot-hackathon.com
+asfiovnxocqpcry.com.cn @cn
+awsapps.cn @cn
+awsapps.com.cn @cn
 awsautopilot.com
 awsautoscaling.com
+aws-border.cn @cn
 awsbraket.com
 awscommandlineinterface.com
 awsedstart.com
@@ -24,15 +31,27 @@ awseducate.com
 awseducate.net
 awseducate.org
 awsglobalaccelerator.com
+aws-icp-domain-manager.cn @cn
+aws-iot-hackathon.com
 awsloft-johannesburg.com
 awsloft-stockholm.com
 awssecworkshops.com
+awsstatic.cn @cn
 awsstatic.com
 awsthinkbox.com
 cdkworkshop.com
+cloudfront.cn @cn
 cloudfront.net
+cloudfront-cn.net @cn
+cloudfront-test.cn @cn
 containersonaws.com
 elasticbeanstalk.com
+nwcdcloud.cn @cn
+nwcdcloud.com.cn @cn
+nwcddns.cn @cn
+nwcdinfosec.cn @cn
+route53.cn @cn
+sagemaker.com.cn @cn
 thinkboxsoftware.com
 
 # AWS DNS
@@ -41,6 +60,7 @@ regexp:.+\.awsdns-[0-9][0-9]\.com$
 regexp:.+\.awsdns-[0-9][0-9]\.net$
 regexp:.+\.awsdns-[0-9][0-9]\.org$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.biz$
-regexp:.+\.awsdns-cn-[0-9][0-9]\.cn$
+regexp:.+\.awsdns-cn-[0-9][az-0-9]\.cn$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.com$
 regexp:.+\.awsdns-cn-[0-9][0-9]\.net$
+regexp:.+\.awsdns-cn-[0-9][0-9]\.top$


### PR DESCRIPTION
宁夏西云数据科技有限公司

`a2z.org.cn` 宁ICP备17000743号-18
`amazonaws.cn` 宁ICP备17000743号-11
`amazonaws.com.cn` 宁ICP备17000743号-11
`amazonwebservices.com.cn` 宁ICP备17000743号-24
`asfiovnxocqpcry.com.cn` 宁ICP备17000743号-19
`aws-border.cn` 宁ICP备17000743号-23
`aws-icp-domain-manager.cn` 宁ICP备17000743号-16
`awsapps.cn` 宁ICP备17000743号-15
`awsapps.com.cn` 宁ICP备17000743号-15
`awsstatic.cn` 宁ICP备17000743号-21
`cloudfront-cn.net` 宁ICP备17000743号-9
`cloudfront-test.cn` 宁ICP备17000743号-17
`cloudfront.cn` 宁ICP备17000743号-10
`nwcdcloud.cn` 宁ICP备17000743号-2
`nwcdcloud.com.cn` 宁ICP备17000743号-2
`nwcddns.cn` 宁ICP备17000743号-3
`nwcdinfosec.cn` 宁ICP备17000743号-22
`route53.cn` 宁ICP备17000743号-4
`sagemaker.com.cn` 宁ICP备17000743号-20

`awsdns-cn-[0-9][a-e0-9]\.cn` 宁ICP备17000743号-5/宁ICP备17000743号-13 (e.g. `awsdns-cn-8b.cn`)
`awsdns-cn-[0-9][0-9]\.biz` 宁ICP备17000743号-8
`awsdns-cn-[0-9][0-9]\.com` 宁ICP备17000743号-6
`awsdns-cn-[0-9][0-9]\.net` 宁ICP备17000743号-7
`awsdns-cn-[0-9][0-9]\.top` 宁ICP备17000743号-14 (e.g. `awsdns-cn-25.top`)