### PR TITLE
Update vultr

### DIFF
--- a/data/vultr
+++ b/data/vultr
@@ -1,1 +1,2 @@
 vultr.com
+vultrusercontent.com


### PR DESCRIPTION
`vultrusercontent.com` rDNS domain for Vultr's IP address.
For example, `108.61.177.131 Paris, Ile-de-France, France, AS20473, AS-CHOOPA - The Constant Company, LLC`
```
# dig -x 108.61.177.131 +short
108.61.177.131.vultrusercontent.com
```