### PR TITLE
Update qcc

### DIFF
--- a/data/qcc
+++ b/data/qcc
@@ -1,1 +1,4 @@
 qcc.com
+qichacha.com
+qcc-static.qcc.com
+qcc-static.qichacha.com

--- a/data/qcc
+++ b/data/qcc
@@ -1,3 +1,2 @@
 qcc.com
-full:qcc-static.qichacha.com
-full:report.qichacha.com
+qichacha.com

--- a/data/qcc
+++ b/data/qcc
@@ -2,3 +2,4 @@ qcc.com
 qichacha.com
 qcc-static.qcc.com
 qcc-static.qichacha.com
+report.qichacha.com

--- a/data/qcc
+++ b/data/qcc
@@ -1,2 +1,3 @@
 qcc.com
-qichacha.com
+full:qcc-static.qichacha.com
+full:report.qichacha.com

--- a/data/qcc
+++ b/data/qcc
@@ -1,5 +1,2 @@
 qcc.com
 qichacha.com
-qcc-static.qcc.com
-qcc-static.qichacha.com
-report.qichacha.com


### PR DESCRIPTION
qcc.com 是企业查询网站 "企查查" .

1. 修复仅添加  qcc.com 一项会导致加载极慢的 issue.  添加此 3 项后，才能秒开。
2. 且，若仅指定 qcc.com 一项, 在导出数据并下载时, 速度极慢.
3. 仅添加 qcc.com qichacha.com 并不能解决这个 issue. 
