### PR TITLE
google: remove some outdated @cn domains

### DIFF
--- a/data/google
+++ b/data/google
@@ -584,8 +584,6 @@ full:ssl.gstatic.com @cn
 full:toolbarqueries.google.com @cn
 full:tools.google.com @cn
 full:tools.l.google.com @cn
-full:translate.googleapis.com @cn
-full:translation.googleapis.com @cn
 full:update.googleapis.com @cn
 full:www-google-analytics.l.google.com @cn
 full:www-googletagmanager.l.google.com @cn


### PR DESCRIPTION
Both of these domains can't be connected to without a proxy in mainland China, so remove them.

Fixes #1224