### PR TITLE
update Hulu

### DIFF
--- a/data/hulu
+++ b/data/hulu
@@ -45,3 +45,4 @@ payhulu.com
 registerhulu.com
 thehulubraintrust.com
 wwwhuluplus.com
+full:hulu.playback.edge.bamgrid.com


### PR DESCRIPTION
```
hulu.playback.edge.bamgrid.com
```
The domain above is for geolocation check, leaving it unproxied would cause playback issues with error codes 'p-dev3xxx'

And this conflicts with the entry "bamgrid.com" of the disney ruleset, make sure the hulu ruleset is prior to the disney one when  using different proxies for these two streaming service