### PR TITLE
Update digicert

### DIFF
--- a/data/digicert
+++ b/data/digicert
@@ -1,5 +1,6 @@
 digicert-cn.com # Not in Chinese Mainland
 
+digicert-validation.com
 digicert.cn @cn
 digicert.com
 digitalcertvalidation.com


### PR DESCRIPTION
`digicert-validation.com` 迪杰斯特网络安全技术（北京）有限公司 京ICP备19045811号-2

The domain is not active.