### PR TITLE
Implement the Consensus of PR#1209 and PR#1237

### DIFF
--- a/data/google
+++ b/data/google
@@ -571,7 +571,6 @@ full:content.googleadapis.com @cn
 full:corp.google.com @cn
 full:corp.googleapis.com @cn
 full:crashlyticsreports-pa.googleapis.com @cn
-full:crl.pki.goog @cn
 full:csi.gstatic.com @cn
 full:dartsearch-cn.net @cn
 full:dg-meta.video.google.com @cn
@@ -631,10 +630,8 @@ full:imasdk.googleapis.com @cn
 full:monitoring.qatp1.net @cn
 full:monitoring.qcpp1.net @cn
 full:monitoring.qpdp1.net @cn
-full:ocsp.pki.goog @cn
 full:pagead-googlehosted.l.google.com @cn
 full:performanceparameters.googleapis.com @cn
-full:pki-goog.l.google.com @cn
 full:play.1ucrs.com @cn
 full:prod-controlbe.floonet.goog @cn
 full:prod-databe.floonet.goog @cn

--- a/data/google-trust-services
+++ b/data/google-trust-services
@@ -5,3 +5,4 @@ full:pki.google.com
 
 full:crl.pki.goog @cn
 full:ocsp.pki.goog @cn
+full:pki-goog.l.google.com @cn

--- a/data/huaweicloud
+++ b/data/huaweicloud
@@ -164,4 +164,3 @@ cdnhwcojn124.cn
 cdnhwcscc123.cn
 
 regexp:.+\.cdnhwc([1-9]|10)\.(cn|com)$
-regexp:.+\.cdnhwc[a-z]{3}[0-9]{2,3}\.(cn|com)$


### PR DESCRIPTION
> ```
>full:crl.pki.goog @cn
>full:ocsp.pki.goog @cn
>full:pki-goog.l.google.com @cn
>```
>已经或应当在 `google-trust-services` 中列出，下次应该过滤此 3 行。

_Originally posted by @KukiSa in https://github.com/v2fly/domain-list-community/issues/1237#issuecomment-1272700875_

---

>目前华为云 CDN CNAME 域名并未铺满 `cdnhwc[a-z]{3}[0-9]{2,3}\.(cn|com)` 涵盖的所有范围，例如：
>```
># dig cdnhwcqfs954.cn soa
>
>; <<>> DiG 9.16.27-Debian <<>> cdnhwcqfs954.cn soa
>;; global options: +cmd
>;; Got answer:
>;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 27322
>;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0
>
>;; QUESTION SECTION:
>;cdnhwcqfs954.cn.               IN      SOA
>
>;; AUTHORITY SECTION:
>cn.                     30      IN      SOA     a.dns.cn. root.cnnic.cn. 2030149109 7200 3600 2419200 21600
>
>;; Query time: 109 msec
>;; SERVER: 172.18.54.1#53(172.18.54.1)
>;; WHEN: Fri Sep 23 23:35:49 CST 2022
>;; MSG SIZE  rcvd: 86
>```
>
>建议还是按原来的方式 (69-164) 枚举。

_Originally posted by @KukiSa in https://github.com/v2fly/domain-list-community/issues/1209#issuecomment-1256367855_
