### PR TITLE
添加  “AIXCoder Java插件”  和  “博客园（cnblogs）”

### DIFF
--- a/data/aixcoder
+++ b/data/aixcoder
@@ -1,0 +1,2 @@
+aixcoder.com
+nnthink.com

--- a/data/category-dev-cn
+++ b/data/category-dev-cn
@@ -1,3 +1,5 @@
+include:aixcoder
+include:cnblogs
 include:coding
 include:csdn
 include:deepin

--- a/data/cnblogs
+++ b/data/cnblogs
@@ -1,0 +1,7 @@
+blogjava.net
+cnblogs.com
+cnitblog.com
+cnweblog.com
+cppblog.com
+phpweblog.net
+teachblog.net


### PR DESCRIPTION
AIXCoder Java插件
aixcoder.com 京ICP备17028945号-2
nnthink.com 京ICP备17028945号-1

博客园（cnblogs） 面向开发者的知识分享社区
blogjava.net 沪ICP备09004260号-1
cnblogs.com 沪ICP备09004260号-1
cnitblog.com 沪ICP备09004260号-1
cnweblog.com 沪ICP备09004260号-1
cppblog.com 沪ICP备09004260号-1
phpweblog.net 沪ICP备09004260号-1
teachblog.net 沪ICP备09004260号-1

合并提交的原因是两者名称在字典序上相邻