### PR TITLE
add onion site for `nytimes`

### DIFF
--- a/data/nytimes
+++ b/data/nytimes
@@ -7,3 +7,4 @@ nyti.ms
 nytimes.com
 nytstyle.com
 timestalks.com
+full:www.nytimesn7cgmftshazwhfgzm37qxb44r64ytbb2dj3x62d2lljsciiyd.onion


### PR DESCRIPTION
https://open.nytimes.com/https-open-nytimes-com-the-new-york-times-as-a-tor-onion-service-e0d0b67b7482