### PR TITLE
Update chaoxing: 'jikeiot.cloud'

### DIFF
--- a/data/chaoxing
+++ b/data/chaoxing
@@ -6,6 +6,7 @@ chaoxing.com
 chaoxingv.com
 cxbiji.com
 hongbo100.com
+jikeiot.cloud
 lnlib.net
 mndqlib.net
 mti100.com


### PR DESCRIPTION
Recently when watching course videos in Chaoxing, I noticed that the browser are querying files from `jikeiot.cloud`.

At first, traffic were going through proxy, which turns out to be quite slow.

After adding `domain:jikeiot.cloud` into "Direct Domains", the videos are playing just fine.
