### PR TITLE
Update google

### DIFF
--- a/data/google
+++ b/data/google
@@ -334,6 +334,7 @@ gateway.dev
 gcr.io
 gerritcodereview.com
 getbumptop.com
+ggpht.com
 ggoogle.com
 gipscorp.com
 gkecnapps.cn @cn


### PR DESCRIPTION
添加 `ggpht.com`
域名来源 [Google Maps Platform Domains](https://developers.google.com/maps/gmp-domains)