### PR TITLE
Dotless domain regex fix

### DIFF
--- a/data/private
+++ b/data/private
@@ -119,7 +119,7 @@ b.e.f.ip6.arpa
 127.100.in-addr.arpa
 
 # Dotless domains
-regexp:^[^.]+$
+regexp:^[-0-9A-Za-z]+$
 
 # Aruba router
 full:instant.arubanetworks.com


### PR DESCRIPTION
Dotless domain should match these rules:

1) Characters should only be a-z | A-Z | 0-9 and dash(-)
2) Should not start or end with dash (-) (e.g. -domain-)
3) Should be between 1 and 63 characters long

Currently it can be any string without dots. 

Related issue: https://github.com/v2fly/domain-list-community/issues/1395