### PR TITLE
Windows network connectivity check domains 

### DIFF
--- a/data/microsoft
+++ b/data/microsoft
@@ -61,6 +61,11 @@ microsoft.ua
 microsoft.uz
 microsoft.vn
 
+# Network Connectivity Status Indicator (NCSI)
+# https://learn.microsoft.com/en-US/troubleshoot/windows-client/networking/internet-explorer-edge-open-connect-corporate-public-network
+msftncsi.com
+msftconnecttest.com
+
 # M12
 femalefounderscomp.com
 m12.vc

--- a/data/private
+++ b/data/private
@@ -148,9 +148,5 @@ tendawifi.com
 # TP-Link router
 tplinkwifi.net
 
-# Windows
-msftconnecttest.com
-msftncsi.com
-
 # 中興路由器
 zte.home


### PR DESCRIPTION
Fix for #1386. As far as I investigated, there are no references that support putting the domains into `private` list.

Ref: https://learn.microsoft.com/en-US/troubleshoot/windows-client/networking/internet-explorer-edge-open-connect-corporate-public-network