### PR TITLE
use prefix match for `mdn.mozit.cloud`

### DIFF
--- a/data/mdn
+++ b/data/mdn
@@ -1,4 +1,4 @@
+mdn.mozit.cloud
 full:developer.mozilla.org
 full:interactive-examples.mdn.mozilla.net
 full:mdn.mozillademos.org
-mdn.mozit.cloud

--- a/data/mdn
+++ b/data/mdn
@@ -1,4 +1,4 @@
 full:developer.mozilla.org
 full:interactive-examples.mdn.mozilla.net
 full:mdn.mozillademos.org
-full:media.prod.mdn.mozit.cloud
+mdn.mozit.cloud


### PR DESCRIPTION
We have used some sub domains for different usages:

- `content.mdn.mozit.cloud`: used for PR preview in mdn/translated-content and mdn/content: such as https://github.com/mdn/translated-content/pull/11300#issuecomment-1407986840
- `stage.mdn.mozit.cloud`: used for stage build in mdn: https://yari-demos.stage.mdn.mozit.cloud/zh-CN/
- `dev.mdn.mozit.cloud`: used for development build in mdn.yari: such as https://esm.content.dev.mdn.mozit.cloud/zh-CN/

So it's better to use `prefix` match instead.