### PR TITLE
Update logitech, okx and patreon

### DIFF
--- a/data/logitech
+++ b/data/logitech
@@ -3,9 +3,11 @@ logicool.co.jp
 logicoolg.com
 logitech.biz
 logitech.com
+logitech.com.cn
 logitech.fr
 logitech.io
 logitechg.com
 logitechg.com.cn
 logitechg.fr
+logitechio.com.cn
 worldsfastestgamer.net

--- a/data/logitech
+++ b/data/logitech
@@ -6,5 +6,6 @@ logitech.com
 logitech.fr
 logitech.io
 logitechg.com
+logitechg.com.cn
 logitechg.fr
 worldsfastestgamer.net

--- a/data/okx
+++ b/data/okx
@@ -1,2 +1,5 @@
 okex.com
 okx.com
+
+# OKC Browser
+oklink.com @cn

--- a/data/patreon
+++ b/data/patreon
@@ -1,2 +1,5 @@
 patreon.com
+patreoncommunity.com
 patreonusercontent.com
+
+full:live-patreon-marketing.pantheonsite.io


### PR DESCRIPTION
It seems that although Logitech has the ICP, his domains have not been resolved to mainland China.
罗技（中国）科技有限公司 沪ICP备12002604号
`logitech.com.cn` 沪ICP备12002604号-1
`logitechg.com.cn` 沪ICP备12002604号-2
`logitechio.com.cn` 沪ICP备12002604号-3

ref: https://www.okx.com/okc
`oklink.com` 北京欧科云链网络信息有限公司 京ICP备20017016号-1