### PR TITLE
Update apple, beats, swift and ucloud

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -105,7 +105,7 @@ apple.xyz
 
 # Apple Store
 aplestore.com
-apple-store.cn @cn
+apple-store.cn
 apple-store.net
 apple-store.wang
 applestor.com
@@ -113,7 +113,7 @@ applestore.bg
 applestore.cc
 applestore.ch
 applestore.cm
-applestore.cn @cn
+applestore.cn
 applestore.co.hu
 applestore.co.jp
 applestore.co.ug
@@ -121,7 +121,7 @@ applestore.co.uk
 applestore.com
 applestore.com.au
 applestore.com.bn
-applestore.com.cn @cn
+applestore.com.cn
 applestore.com.ee
 applestore.com.eg
 applestore.com.gr
@@ -153,8 +153,8 @@ onlineapplestore.com
 # App Store
 app-store.wang
 appe-store.com
-apple-appstore.cn @cn
-appleappstore.cn @cn
+apple-appstore.cn
+appleappstore.cn
 appleappstore.net
 appleappstore.tv
 appsto.re
@@ -162,7 +162,7 @@ appstore.co.id
 appstore.hk
 appstore.my
 appstore.ph
-appstoreapple.cn @cn
+appstoreapple.cn
 asto.re
 tvappstore.net
 
@@ -220,7 +220,7 @@ fundaiphone5s.com
 hebiphone.com
 hf-iphone.com
 iphine.com
-iphone-8.com.cn @cn
+iphone-8.com.cn
 iphone-cd.com
 iphone-cn.com
 iphone-sh.com
@@ -280,7 +280,7 @@ ipod.co.uk
 ipod.co.za
 ipod.com
 ipod.com.au
-ipod.com.cn @cn
+ipod.com.cn
 ipod.com.fr
 ipod.com.hk
 ipod.com.sg
@@ -323,12 +323,12 @@ macbook.co
 macbook.hk
 macbook.tw
 macbook.wang
-macbookair.cn @cn
+macbookair.cn
 macbookair.co.kr
 macbookair.co.uk
 macbookair.com
 macbookair.com.au
-macbookair.com.cn @cn
+macbookair.com.cn
 macbookair.com.es
 macbookair.es
 macbookair.hk
@@ -388,15 +388,15 @@ applepay.info
 applepay.jp
 applepay.rs
 applepay.tv
-applepaycash.cn @cn
-applepaycash.com.cn @cn
+applepaycash.cn
+applepaycash.com.cn
 applepaycash.net
 applepaycash.tv
 applepaymerchantsupplies.info
 applepaysupplies.berlin
-applepaysupplies.cn @cn
+applepaysupplies.cn
 applepaysupplies.com
-applepaysupplies.com.cn @cn
+applepaysupplies.com.cn
 applepaysupplies.info
 applepaysupplies.net
 applepaysupplies.tv
@@ -455,8 +455,8 @@ myappleid.com
 appletv.com
 appletv.fr
 appletv.wang
-appletv4.cn @cn
-appletv4.com.cn @cn
+appletv4.cn
+appletv4.com.cn
 appletvapp.apple
 
 # Apple One
@@ -509,10 +509,10 @@ apple-enews.com
 apple-expo.com
 apple-expo.eu
 apple-hk.com
-apple-ibooks.cn @cn
+apple-ibooks.cn
 apple-inc.net
 apple-livephotoskit.com
-apple-maps.cn @cn
+apple-maps.cn
 apple-online.com
 apple-usa.net
 appleafrica.com
@@ -525,18 +525,18 @@ applecarbon.com
 applecard.tv
 applecentar.co.rs
 applecentar.rs
-applecenter.cn @cn
-applecenter.com.cn @cn
+applecenter.cn
+applecenter.com.cn
 applecentre.com.au
 applecentre.info
 appleclub.com.hk
 applecom.com
 applecomputer-imac.com
-applecomputer.cn @cn
+applecomputer.cn
 applecomputer.co.in
 applecomputer.co.nz
 applecomputer.com
-applecomputer.com.cn @cn
+applecomputer.com.cn
 applecomputer.com.hk
 applecomputer.com.tw
 applecomputer.hu
@@ -578,7 +578,7 @@ applescreensavers.com
 applescript.info
 appleshare.info
 appleshop.co.uk
-applesiri.cn @cn
+applesiri.cn
 applesurveys.com
 appletaiwan.com
 appletips.net
@@ -626,7 +626,7 @@ dvdstudiopro.net
 dvdstudiopro.org
 dvdstudiopro.us
 earpod.net
-ecgapp.com.cn @cn
+ecgapp.com.cn
 ecgapp.net
 edu-research.org
 emac.co.in
@@ -636,14 +636,14 @@ eworld.com
 faceid99.com
 faceid99.net
 faceidglobal.com
-faceshift.cn @cn
+faceshift.cn
 facetime.net
 finalcutpro.com
 find-apple.com
 firewire.cl
 firewire.eu
 geoport.com
-homepod.cn @cn
+homepod.cn
 hopstop.tv
 ichat.co.in
 idvd.eu
@@ -653,7 +653,7 @@ ilife.eu
 ilife.gr
 ilife.wang
 imessage.tv
-insidear.cn @cn
+insidear.cn
 insidemacintosh.com
 iosinthecar.com
 ipa-iphone.net
@@ -666,8 +666,8 @@ iwork.wang
 jetfuelapp.com
 jetfuelapps.com
 latticedata.com
-livephotos.cn @cn
-livephotos.com.cn @cn
+livephotos.cn
+livephotos.com.cn
 livephotos.tv
 lojaiphone.com.br
 mac-mini.com
@@ -734,7 +734,7 @@ xn--gtvz22d.wang # 苹果.wang
 xn--gtvz22d.xn--hxt814e # 苹果.网店
 xn--hxtr4rozx.xn--czr694b # 苹果店.商标
 xn--kput3imi374g.xn--hxt814e # 苹果手机.网店
-xn--ohq11k7pl25iyo8a.cn @cn # 苹果专卖店.cn
+xn--ohq11k7pl25iyo8a.cn # 苹果专卖店.cn
 xn--ruq8a011kt6y.xn--hxt814e # 苹果保修.网店
 
 full:apple.com.akadns.net

--- a/data/apple
+++ b/data/apple
@@ -105,7 +105,7 @@ apple.xyz
 
 # Apple Store
 aplestore.com
-apple-store.cn
+apple-store.cn @cn
 apple-store.net
 apple-store.wang
 applestor.com
@@ -113,7 +113,7 @@ applestore.bg
 applestore.cc
 applestore.ch
 applestore.cm
-applestore.cn
+applestore.cn @cn
 applestore.co.hu
 applestore.co.jp
 applestore.co.ug
@@ -121,7 +121,7 @@ applestore.co.uk
 applestore.com
 applestore.com.au
 applestore.com.bn
-applestore.com.cn
+applestore.com.cn @cn
 applestore.com.ee
 applestore.com.eg
 applestore.com.gr
@@ -153,8 +153,8 @@ onlineapplestore.com
 # App Store
 app-store.wang
 appe-store.com
-apple-appstore.cn
-appleappstore.cn
+apple-appstore.cn @cn
+appleappstore.cn @cn
 appleappstore.net
 appleappstore.tv
 appsto.re
@@ -162,7 +162,7 @@ appstore.co.id
 appstore.hk
 appstore.my
 appstore.ph
-appstoreapple.cn
+appstoreapple.cn @cn
 asto.re
 tvappstore.net
 
@@ -220,7 +220,7 @@ fundaiphone5s.com
 hebiphone.com
 hf-iphone.com
 iphine.com
-iphone-8.com.cn
+iphone-8.com.cn @cn
 iphone-cd.com
 iphone-cn.com
 iphone-sh.com
@@ -280,7 +280,7 @@ ipod.co.uk
 ipod.co.za
 ipod.com
 ipod.com.au
-ipod.com.cn
+ipod.com.cn @cn
 ipod.com.fr
 ipod.com.hk
 ipod.com.sg
@@ -323,12 +323,12 @@ macbook.co
 macbook.hk
 macbook.tw
 macbook.wang
-macbookair.cn
+macbookair.cn @cn
 macbookair.co.kr
 macbookair.co.uk
 macbookair.com
 macbookair.com.au
-macbookair.com.cn
+macbookair.com.cn @cn
 macbookair.com.es
 macbookair.es
 macbookair.hk
@@ -388,15 +388,15 @@ applepay.info
 applepay.jp
 applepay.rs
 applepay.tv
-applepaycash.cn
-applepaycash.com.cn
+applepaycash.cn @cn
+applepaycash.com.cn @cn
 applepaycash.net
 applepaycash.tv
 applepaymerchantsupplies.info
 applepaysupplies.berlin
-applepaysupplies.cn
+applepaysupplies.cn @cn
 applepaysupplies.com
-applepaysupplies.com.cn
+applepaysupplies.com.cn @cn
 applepaysupplies.info
 applepaysupplies.net
 applepaysupplies.tv
@@ -455,8 +455,8 @@ myappleid.com
 appletv.com
 appletv.fr
 appletv.wang
-appletv4.cn
-appletv4.com.cn
+appletv4.cn @cn
+appletv4.com.cn @cn
 appletvapp.apple
 
 # Apple One
@@ -509,10 +509,10 @@ apple-enews.com
 apple-expo.com
 apple-expo.eu
 apple-hk.com
-apple-ibooks.cn
+apple-ibooks.cn @cn
 apple-inc.net
 apple-livephotoskit.com
-apple-maps.cn
+apple-maps.cn @cn
 apple-online.com
 apple-usa.net
 appleafrica.com
@@ -525,18 +525,18 @@ applecarbon.com
 applecard.tv
 applecentar.co.rs
 applecentar.rs
-applecenter.cn
-applecenter.com.cn
+applecenter.cn @cn
+applecenter.com.cn @cn
 applecentre.com.au
 applecentre.info
 appleclub.com.hk
 applecom.com
 applecomputer-imac.com
-applecomputer.cn
+applecomputer.cn @cn
 applecomputer.co.in
 applecomputer.co.nz
 applecomputer.com
-applecomputer.com.cn
+applecomputer.com.cn @cn
 applecomputer.com.hk
 applecomputer.com.tw
 applecomputer.hu
@@ -578,7 +578,7 @@ applescreensavers.com
 applescript.info
 appleshare.info
 appleshop.co.uk
-applesiri.cn
+applesiri.cn @cn
 applesurveys.com
 appletaiwan.com
 appletips.net
@@ -626,7 +626,7 @@ dvdstudiopro.net
 dvdstudiopro.org
 dvdstudiopro.us
 earpod.net
-ecgapp.com.cn
+ecgapp.com.cn @cn
 ecgapp.net
 edu-research.org
 emac.co.in
@@ -636,14 +636,14 @@ eworld.com
 faceid99.com
 faceid99.net
 faceidglobal.com
-faceshift.cn
+faceshift.cn @cn
 facetime.net
 finalcutpro.com
 find-apple.com
 firewire.cl
 firewire.eu
 geoport.com
-homepod.cn
+homepod.cn @cn
 hopstop.tv
 ichat.co.in
 idvd.eu
@@ -653,7 +653,7 @@ ilife.eu
 ilife.gr
 ilife.wang
 imessage.tv
-insidear.cn
+insidear.cn @cn
 insidemacintosh.com
 iosinthecar.com
 ipa-iphone.net
@@ -666,8 +666,8 @@ iwork.wang
 jetfuelapp.com
 jetfuelapps.com
 latticedata.com
-livephotos.cn
-livephotos.com.cn
+livephotos.cn @cn
+livephotos.com.cn @cn
 livephotos.tv
 lojaiphone.com.br
 mac-mini.com
@@ -726,15 +726,15 @@ www-sms-apple.com
 wwwapple.com
 wwwapple.net
 wwwlapple.com
-xn--czrs0t4phtr3a.cn # 苹果商店.cn
-xn--fiqs8sxootzz.cn # 苹果中国.cn
+xn--czrs0t4phtr3a.cn @cn # 苹果商店.cn
+xn--fiqs8sxootzz.cn @cn # 苹果中国.cn
 xn--fiqs8sxootzz.xn--hxt814e # 苹果中国.网店
 xn--gtvq61aiijy0b.xn--hxt814e # 苹果电脑.网店
 xn--gtvz22d.wang # 苹果.wang
 xn--gtvz22d.xn--hxt814e # 苹果.网店
 xn--hxtr4rozx.xn--czr694b # 苹果店.商标
 xn--kput3imi374g.xn--hxt814e # 苹果手机.网店
-xn--ohq11k7pl25iyo8a.cn # 苹果专卖店.cn
+xn--ohq11k7pl25iyo8a.cn @cn # 苹果专卖店.cn
 xn--ruq8a011kt6y.xn--hxt814e # 苹果保修.网店
 
 full:apple.com.akadns.net

--- a/data/beats
+++ b/data/beats
@@ -111,6 +111,8 @@ beatsbydre-sell.com
 beatsbydre-store.com
 beatsbydre-studio.com
 beatsbydre-us.com
+beatsbydre.com @cn
+beatsbydre.com.cn @cn
 beatsbydre.jp
 beatsbydre2081.com
 beatsbydre411.com

--- a/data/beats
+++ b/data/beats
@@ -63,12 +63,12 @@ beats-sale.com
 beats-seller.com
 beats-soaho.com
 beats1.cc
-beats1.cn @cn
+beats1.cn
 beats1.tv
-beats1.com.cn @cn
+beats1.com.cn
 beats123.com
-beats2.com.cn @cn
-beats4.cn @cn
+beats2.com.cn
+beats4.cn
 beats4.net
 beats4outlets.com
 beats4salecheap.com
@@ -246,7 +246,7 @@ beatsforme.com
 beatsfranceofficiel.com
 beatselectronic.net
 beatselectronics.com
-beatsep.cn @cn
+beatsep.cn
 beatsep.com
 beatsep.net
 beatsheadphones-discount.com

--- a/data/beats
+++ b/data/beats
@@ -63,12 +63,12 @@ beats-sale.com
 beats-seller.com
 beats-soaho.com
 beats1.cc
-beats1.cn
+beats1.cn @cn
 beats1.tv
-beats1.com.cn
+beats1.com.cn @cn
 beats123.com
-beats2.com.cn
-beats4.cn
+beats2.com.cn @cn
+beats4.cn @cn
 beats4.net
 beats4outlets.com
 beats4salecheap.com
@@ -246,7 +246,7 @@ beatsforme.com
 beatsfranceofficiel.com
 beatselectronic.net
 beatselectronics.com
-beatsep.cn
+beatsep.cn @cn
 beatsep.com
 beatsep.net
 beatsheadphones-discount.com

--- a/data/swift
+++ b/data/swift
@@ -1,4 +1,4 @@
 appleswift.com
 swift.org
-swiftui.cn @cn
-swiftui.com.cn @cn
+swiftui.cn
+swiftui.com.cn

--- a/data/swift
+++ b/data/swift
@@ -1,4 +1,4 @@
 appleswift.com
 swift.org
-swiftui.cn
-swiftui.com.cn
+swiftui.cn @cn
+swiftui.com.cn @cn

--- a/data/ucloud
+++ b/data/ucloud
@@ -29,7 +29,6 @@ ucloudnaming.info
 ucloudnaming.net
 ucloudoss.com
 ucloudstack.cn
-ucloudstack.cn
 ucloudstack.com
 ucloudstack.net
 ucloudstor.com


### PR DESCRIPTION
`beatsbydre.com` 苹果电子产品商贸（北京）有限公司 京ICP备10214630号-4
`beatsbydre.com.cn` 苹果电子产品商贸（北京）有限公司 京ICP备10214630号-5

`apple-store.cn`, `applestore.cn`, `applestore.com.cn`, `apple-appstore.cn`, `appleappstore.cn`, `appstoreapple.cn`, `iphone-8.com.cn`, `ipod.com.cn`, `macbookair.cn`, `macbookair.cn`, `applepaycash.cn`, `applepaycash.com.cn`, `applepaysupplies.cn`, `applepaysupplies.com.cn`, `appletv4.cn`, `appletv4.com.cn`, `apple-ibooks.cn`, `apple-maps.cn`, `applecenter.cn`, `applecenter.com.cn`, `applecomputer.cn`, `applecomputer.com.cn`, `applesiri.cn`, `ecgapp.com.cn`, `faceshift.cn`, `homepod.cn`, `insidear.cn`, `livephotos.cn`, `livephotos.com.cn`, `xn--ohq11k7pl25iyo8a.cn`, `swiftui.cn`, `swiftui.com.cn`, `beatsep.cn`, `beats1.cn`, `beats1.com.cn`, `beats2.com.cn`, `beats4.cn` 已不存在备案。

```
# dig www.applestore.cn +short
applestore.cn.
17.253.142.4
```

```
# dig www.applestore.com.cn +short
applestore.com.cn.
17.253.142.4
```

```
# dig www.ipod.com.cn +short
ipod.com.cn.
17.253.142.4
```

```
# dig www.macbookair.com.cn +short
macbookair.com.cn.
17.253.142.4
```

```
# dig www.applecomputer.cn +short
applecomputer.cn.
17.253.142.4
```

```
# dig www.applecomputer.com.cn +short
applecomputer.com.cn.
17.253.142.4
```

`17.253.142.4` 美国 apple.com

其他被削去 `@cn` 标记的条目已经没有有效的 DNS 记录。

---

至于 `ucloud` 那个，我也不知道怎么会多出一条重复的条目来。经查实 `沪ICP备12020087号-19` 没有对应的域名，`ucloudstack.cn` 只对应 `沪ICP备12020087号-14`。