### PR TITLE
ci: setup go with the go version in go.mod file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,21 +11,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+        with:
+          path: code
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version-file: code/go.mod
 
       - name: Set variables
         run: |
           echo "RELEASE_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
         shell: bash
-
-      - name: Checkout codebase
-        uses: actions/checkout@v3
-        with:
-          path: code
 
       - name: Build dlc.dat file
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
 
       - name: Set variables
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+        with:
+          path: code
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: go.mod
+          go-version-file: code/go.mod
 
       - name: Set variables
         run: |
           echo "RELEASE_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
         shell: bash
-
-      - name: Checkout codebase
-        uses: actions/checkout@v3
-        with:
-          path: code
 
       - name: Build dlc.dat file
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
 
       - name: Set variables
         run: |


### PR DESCRIPTION
See: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file

We can now install the specific go version provided by go.mod file. It will be more easy for us to bump go version.