### PR TITLE
feat: add quay to category-dev

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -123,6 +123,7 @@ php.net
 putty.org
 
 postgresql.org
+quay.io
 r-project.org
 raspberrypi.org
 raspbian.org


### PR DESCRIPTION
As the title suggests, this PR adds `quay` to category-dev.txt

This includes `quay.io` for example to support [quay container image registry](https://quay.io)