### PR TITLE
add `developer.allizom.org` to MDN and change a rule of a full match domain

### DIFF
--- a/data/mdn
+++ b/data/mdn
@@ -1,5 +1,6 @@
+developer.allizom.org
+developer.mozilla.org
 mdn.mozit.cloud
 
-full:developer.mozilla.org
 full:interactive-examples.mdn.mozilla.net
 full:mdn.mozillademos.org


### PR DESCRIPTION
Now, MDN uses `allizom.org` for stage build, and use a sub domain `bcd.developer.{allizom|mozilla}.org` to show the [BCD (browser compatibility data) table](https://developer.mozilla.org/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables#%E5%85%BC%E5%AE%B9%E6%80%A7%E8%A1%A8%E6%A0%BC%E7%A4%BA%E4%BE%8B) in MDN.

Additionally, MDN uses `updates.developer.{allizom|mozilla}.org` to show the [browser feature updates](https://developer.mozilla.org/en-US/plus/updates) (see: https://github.com/mdn/yari/blob/0c2fd32db56d04a4bd76af712d1d80bee116f75c/libs/constants/index.js#L99-L100). So let's modify the full match rule of `developer.mozilla.org`.

Reference: mdn/yari#8470.