### PR TITLE
Update private

### DIFF
--- a/data/private
+++ b/data/private
@@ -126,14 +126,16 @@ full:instant.arubanetworks.com
 full:setmeup.arubanetworks.com
 
 # ASUS router
+full:asusrouter.com
 full:router.asus.com
-asusrouter.com
+full:www.asusrouter.com
 
 # KDE
 networkcheck.kde.org
 
 # Netgear router
-routerlogin.com
+full:routerlogin.com
+full:www.routerlogin.com
 
 # Other router
 hiwifi.com
@@ -159,7 +161,8 @@ msftconnecttest.com
 msftncsi.com
 
 # Xiaomi router
-miwifi.com
+full:miwifi.com
+full:www.mifiwi.com
 
 # ZTE router
 zte.home

--- a/data/private
+++ b/data/private
@@ -154,7 +154,7 @@ tendawifi.com
 
 # TP-Link router
 tplinkwifi.net
-tplogin.cn
+full:tplogin.cn
 
 # Windows
 msftconnecttest.com

--- a/data/private
+++ b/data/private
@@ -126,6 +126,7 @@ full:instant.arubanetworks.com
 full:setmeup.arubanetworks.com
 
 # ASUS router
+# Reference: https://www.asus.com/support/FAQ/1005263/
 full:asusrouter.com
 full:router.asus.com
 full:www.asusrouter.com
@@ -134,6 +135,8 @@ full:www.asusrouter.com
 networkcheck.kde.org
 
 # Netgear router
+# Reference: https://kb.netgear.com/27199/I-can-t-access-my-router-what-do-I-do
+# https://www.netgear.com/business/services/aplogincom/
 full:routerlogin.com
 full:www.routerlogin.com
 
@@ -145,6 +148,10 @@ peiluyou.com
 phicomm.me
 router.ctc
 
+# Plex Media Server
+# Reference: https://support.plex.tv/articles/206225077-how-to-use-secure-server-connections/
+plex.direct
+
 # QQ SSO for quick login
 localhost.sec.qq.com
 localhost.ptlogin2.qq.com
@@ -153,6 +160,7 @@ localhost.ptlogin2.qq.com
 tendawifi.com
 
 # TP-Link router
+# Reference: https://resource.tp-link.com.cn/m/productClass/product_document?id=1655112502304621
 tplinkwifi.net
 full:tplogin.cn
 
@@ -161,6 +169,7 @@ msftconnecttest.com
 msftncsi.com
 
 # Xiaomi router
+# Reference: https://www1.miwifi.com/miwifi_faq.html
 full:miwifi.com
 full:www.mifiwi.com
 

--- a/data/private
+++ b/data/private
@@ -126,7 +126,7 @@ full:instant.arubanetworks.com
 full:setmeup.arubanetworks.com
 
 # ASUS router
-router.asus.com
+full:router.asus.com
 asusrouter.com
 
 # KDE

--- a/data/private
+++ b/data/private
@@ -126,22 +126,24 @@ full:instant.arubanetworks.com
 full:setmeup.arubanetworks.com
 
 # ASUS router
-full:router.asus.com
+router.asus.com
+asusrouter.com
 
 # KDE
 networkcheck.kde.org
 
+# Netgear router
+routerlogin.com
+
 # Other router
 hiwifi.com
 leike.cc
-miwifi.com
 my.router
 peiluyou.com
 phicomm.me
 router.ctc
-routerlogin.com
 
-# QQ Loopback
+# QQ SSO for quick login
 localhost.sec.qq.com
 localhost.ptlogin2.qq.com
 
@@ -150,10 +152,14 @@ tendawifi.com
 
 # TP-Link router
 tplinkwifi.net
+tplogin.cn
 
 # Windows
 msftconnecttest.com
 msftncsi.com
 
-# 中興路由器
+# Xiaomi router
+miwifi.com
+
+# ZTE router
 zte.home


### PR DESCRIPTION
Added
- Added `full:asusrouter.com`/`full:www.asusrouter.com` used by new firmware of ASUS routers.
- Added `full:tplogin.cn` used by TP-Link routers of mainland China version.
- Added `plex.direct` used by Plex Media Server on NAS/HTPC.

Changed
- Reclassified `miwifi.com` to Xiaomi routers and changed to `full:miwifi.com`/`full:www.miwifi.com`.
- Reclassified `routerlogin.com` to Netgear routers and changed to `full:routerlogin.com`/`full:www.routerlogin.com`.
- Modified some comments.