### PR TITLE
Update tld-!cn

### DIFF
--- a/data/tld-!cn
+++ b/data/tld-!cn
@@ -48,7 +48,6 @@ bw # Botswana
 by # Belarus
 bz # Belize
 ca # Canada
-cc # Cocos (Keeling) Islands
 cd # Congo, Democratic Republic of the (Congo-Kinshasa)
 cf # Central African Republic
 cg # Congo, Republic of the (Congo-Brazzaville)
@@ -57,7 +56,6 @@ ci # Côte d’Ivoire (Ivory Coast)
 ck # Cook Islands
 cl # Chile
 cm # Cameroon
-co # Colombia
 cr # Costa Rica
 cu # Cuba
 cv # Cape Verde (Cabo Verde)
@@ -148,7 +146,6 @@ ly # Libya
 ma # Morocco
 mc # Monaco
 md # Moldova
-me # Montenegro
 mf # Saint Martin (officially the Collectivity of Saint Martin)
 mg # Madagascar
 mh # Marshall Islands
@@ -194,7 +191,6 @@ pr # Puerto Rico
 ps # Gaza Strip (Gaza)
 ps # Palestine
 pt # Portugal
-pw # Palau
 py # Paraguay
 qa # Qatar
 re # Réunion Island


### PR DESCRIPTION
According to the [list](https://domain.miit.gov.cn) of domain name suffixes that can be filed according to the Ministry of Industry and Information Technology in the People's Republic of China, I removed some domain suffixes.

fix #1606 