### PR TITLE
Remove .me from tld-!cn

### DIFF
--- a/data/tld-!cn
+++ b/data/tld-!cn
@@ -148,7 +148,6 @@ ly # Libya
 ma # Morocco
 mc # Monaco
 md # Moldova
-me # Montenegro
 mf # Saint Martin (officially the Collectivity of Saint Martin)
 mg # Madagascar
 mh # Marshall Islands


### PR DESCRIPTION
关联 issue https://github.com/v2fly/domain-list-community/issues/1606

.me 域名如今可以视为国际域名，大多被用来作为个人博客之类的网站，国内也有大量这种站点，加入 tld-!cn 会导致这类站点默认都走代理