### PR TITLE
add samandehi.ir

### DIFF
--- a/data/category-ir-gov
+++ b/data/category-ir-gov
@@ -23,6 +23,7 @@ parliran.ir
 president.ir
 refahi.ir
 sahamedalat.ir
+samandehi.ir
 samanese.ir
 sccr.ir
 shora-gc.ir


### PR DESCRIPTION
Adding samandehi.ir (related to https://github.com/v2fly/domain-list-community/pull/1628#issuecomment-1523721485). Based on [the about page](https://samandehi.ir/SitePages/Info.aspx), this is the website of a government-affiliated organization.