### PR TITLE
add some iranian websites

### DIFF
--- a/data/category-ir-gov
+++ b/data/category-ir-gov
@@ -20,6 +20,7 @@ irimo.ir
 moi.ir
 mporg.ir
 parliran.ir
+post.ir
 president.ir
 refahi.ir
 sahamedalat.ir

--- a/data/category-ir-news
+++ b/data/category-ir-news
@@ -35,6 +35,7 @@ snn.ir
 sobhanehonline.com
 tabnak.ir
 tasnimnews.com
+tejaratnews.com
 yjc.ir
 
 # Newspapers

--- a/data/category-ir-social-media
+++ b/data/category-ir-social-media
@@ -4,5 +4,7 @@ bale.ai
 eitaa.com
 eitaa.ir
 gap.im
+niniban.com
+ninisite.com
 rubika.ir
 splus.ir

--- a/data/category-ir-tech
+++ b/data/category-ir-tech
@@ -30,3 +30,4 @@ taliya.ir
 tapsell.ir
 tci.ir
 yektanet.com
+zoomit.ir


### PR DESCRIPTION
Adding some iranian websites. 

Note that despite having `.com` TLD, niniban.com, ninisite.com, and tejaratnews.com are all hosted inside Iran:

https://ipgeolocation.io/ip-location/ninisite.com
https://ipgeolocation.io/ip-location/niniban.com
https://ipgeolocation.io/ip-location/tejaratnews.com
