### PR TITLE
add `mdn.dev`

### DIFF
--- a/data/mdn
+++ b/data/mdn
@@ -1,5 +1,6 @@
 developer.allizom.org
 developer.mozilla.org
+mdn.dev
 mdn.mozit.cloud
 
 full:interactive-examples.mdn.mozilla.net


### PR DESCRIPTION
MDN is now using `mdn.dev` to serve some archived media files, add this to the "mdn" entry.

- mdn/translated-content#13291
- mdn/yari#8873
