### PR TITLE
Update bandwagonhost

### DIFF
--- a/data/bandwagonhost
+++ b/data/bandwagonhost
@@ -2,3 +2,4 @@ bandwagonhost.com
 bwh1.net
 bwh8.net
 bwh88.net
+bwh81.net

--- a/data/bandwagonhost
+++ b/data/bandwagonhost
@@ -1,5 +1,6 @@
 bandwagonhost.com
 bwh1.net
 bwh8.net
-bwh88.net
 bwh81.net
+bwh88.net
+bwh89.net


### PR DESCRIPTION
bwh81.net is a new official mirror website of bandwagonhost.