### PR TITLE
Add zxinc.org

### DIFF
--- a/data/zxinc
+++ b/data/zxinc
@@ -1,0 +1,1 @@
+zxinc.org


### PR DESCRIPTION
https://ip.zxinc.org/ipquery/

This site displays IPv4 and IPv6 addresses of the viewer simultaneously, and one of the two addresses can be the client's local address, causing a physical location clash.