### PR TITLE
Add zxinc.org

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1425,6 +1425,7 @@ zuhaowan.com
 zuidaima.com
 zuowen8.com
 zuowenwang.net
+zxinc.org
 
 # 京ICP备12006877号-1
 fm3838.com


### PR DESCRIPTION
https://ip.zxinc.org/ipquery/

This site displays IPv4 and IPv6 addresses of the viewer simultaneously, and one of the two addresses can be the client's local address, causing a physical location clash.