### PR TITLE
Update kaggle; editor domain added

### DIFF
--- a/data/kaggle
+++ b/data/kaggle
@@ -1,3 +1,4 @@
 kaggle.com
 kaggle.io
 kaggleusercontent.com
+kaggle.net

--- a/data/kaggle
+++ b/data/kaggle
@@ -1,4 +1,4 @@
 kaggle.com
 kaggle.io
-kaggleusercontent.com
 kaggle.net
+kaggleusercontent.com


### PR DESCRIPTION
`kaggle.net` is added to kaggle domain. It is the main domain for the editor of Kaggle.