### PR TITLE
add mdn playground domain names

### DIFF
--- a/data/mdn
+++ b/data/mdn
@@ -2,7 +2,9 @@ developer.allizom.org
 developer.mozilla.org
 mdn.allizom.net
 mdn.dev
-mdn.mozit.cloud
 mdn.mozilla.net
+mdn.mozit.cloud
+mdnplay.dev
+mdnyalp.dev
 
 full:mdn.mozillademos.org


### PR DESCRIPTION
See <https://github.com/mdn/yari/pull/9117/files#diff-2d923597ef410cce4925a914b11712bfba31a01ed0e792ae88ee5240c5dd1557>. MDN has added playground to host live samples.

Check <https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_images/Using_CSS_gradients>. The live sample has used domain "live.mdnplay.dev".

![image](https://github.com/v2fly/domain-list-community/assets/15844309/13930f9a-d3bb-410c-8071-fc3fc0f2093e)

While another domain "live.mdnyalp.dev" is used in pr preview in mdn/content and mdn/translated-content (check <https://github.com/mdn/translated-content/pull/14103>).