### PR TITLE
Remove supercell.com from tencent-games

### DIFF
--- a/data/tencent-games
+++ b/data/tencent-games
@@ -88,6 +88,7 @@ sccreators.cn @cn
 scescdn.cn @cn
 scid.cn @cn
 scsentry.cn @cn
+supercell.com @!cn
 supercellcommunity.cn @cn
 supercellsupport.cn @cn
 

--- a/data/tencent-games
+++ b/data/tencent-games
@@ -88,7 +88,6 @@ sccreators.cn @cn
 scescdn.cn @cn
 scid.cn @cn
 scsentry.cn @cn
-supercell.com
 supercellcommunity.cn @cn
 supercellsupport.cn @cn
 


### PR DESCRIPTION
supercell.com相关域名经过Amazon CloudFront后不在中国境内