### PR TITLE
Update `mozilla` and `category-ipfs`

### DIFF
--- a/data/category-ipfs
+++ b/data/category-ipfs
@@ -16,6 +16,7 @@ ipfs.fleek.co
 ipfs.io
 ipfs.lain.la
 ipfs.runfission.com
+ipfs.tech
 ipns.co
 jorropo.net
 nftstorage.link

--- a/data/mozilla
+++ b/data/mozilla
@@ -2,6 +2,7 @@ include:firefox
 include:mdn
 include:rust
 
+mozgcp.net
 mozilla.com
 mozilla.community
 mozilla.net


### PR DESCRIPTION
1. Firefox sends data to this domain. See https://www.reddit.com/r/firefox/comments/cplazy/why_does_firefox_send_use_googles_servers/
2. One of its subdomains redirects to mozilla.org. See https://prod.oidc-proxy.prod.webservices.mozgcp.net/waitlist