### PR TITLE
Update `tencent`

### DIFF
--- a/data/tencent
+++ b/data/tencent
@@ -38,6 +38,7 @@ tencent.net
 tencent.net.cn
 tencentmusic.com
 tenpay.com
+tfogc.com
 wechat.com
 weiyun.com
 


### PR DESCRIPTION
1. WeChat updates query this domain.
2. Its ICP shows it belongs to Tencent. See https://www.icpapi.com/tfogc.com/