### PR TITLE
Update xiaomi , Add app store cdn

### DIFF
--- a/data/xiaomi
+++ b/data/xiaomi
@@ -9,3 +9,6 @@ xiaomi.net
 
 # Xiaomi YouPin
 xiaomiyoupin.com
+
+# AppStore CDN
+saxyit.com


### PR DESCRIPTION
使用分流的过程中，发现小米应用商城下载APP会走代理
经日志发现，saxyit.com这个域名没匹配到规则

https://sites.ipaddress.com/saxyit.com/

