### PR TITLE
Add nubia

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -272,6 +272,7 @@ include:iflytek
 include:kingsoft
 include:meizu
 include:netease
+include:nubia
 include:oppo
 include:oneplus
 include:qihoo360

--- a/data/nubia
+++ b/data/nubia
@@ -1,0 +1,2 @@
+nubia.cn
+nubia.com


### PR DESCRIPTION
`nubia.cn` redirects to `nubia.com`, which is owned by Chinese company (努比亚) producing smartphones and so on.