### PR TITLE
Add vivo

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -282,6 +282,7 @@ include:qihoo360
 include:sina
 include:sogou
 include:tencent
+include:vivo
 include:xiaomi
 include:xunlei
 

--- a/data/vivo
+++ b/data/vivo
@@ -1,0 +1,3 @@
+vivo.com @cn
+vivo.com.cn @cn
+vivoglobal.com

--- a/data/vivo
+++ b/data/vivo
@@ -1,3 +1,3 @@
-vivo.com @cn
-vivo.com.cn @cn
-vivoglobal.com
+vivo.com
+vivo.com.cn
+vivoglobal.com @!cn


### PR DESCRIPTION
The domain of VIVO sometimes resolves to an IP far away from the local one, which requires introducing GeoSite rules or domain name rules to guide it.

VIVO 的域某些时候会解析到远离本地的 IP ，需要引入 GeoSite 规则或域名规则加以引导。