### PR TITLE
Adding globalsign.com.br from GlobalSign

### DIFF
--- a/data/globalsign
+++ b/data/globalsign
@@ -1,13 +1,13 @@
 alphassl.com
 globalsign-media.com
 globalsign.be
+globalsign.com.br
 globalsign.ch
 globalsign.co.uk
 globalsign.com
 globalsign.com.au
 globalsign.com.hk
 globalsign.com.sg
-globalsign.com.br
 globalsign.es
 globalsign.eu
 globalsign.fr

--- a/data/globalsign
+++ b/data/globalsign
@@ -1,11 +1,11 @@
 alphassl.com
 globalsign-media.com
 globalsign.be
-globalsign.com.br
 globalsign.ch
 globalsign.co.uk
 globalsign.com
 globalsign.com.au
+globalsign.com.br
 globalsign.com.hk
 globalsign.com.sg
 globalsign.es

--- a/data/globalsign
+++ b/data/globalsign
@@ -7,6 +7,7 @@ globalsign.com
 globalsign.com.au
 globalsign.com.hk
 globalsign.com.sg
+globalsign.com.br
 globalsign.es
 globalsign.eu
 globalsign.fr


### PR DESCRIPTION
This domain belongs to GlobalSign and was registered at Registro.br with Toweb Brasil LTDA EPP. Whois: https://registro.br/tecnologia/ferramentas/whois?search=globalsign.com.br