### PR TITLE
Update netflix for device and region detect domains

### DIFF
--- a/data/netflix
+++ b/data/netflix
@@ -26,6 +26,8 @@ netflixdnstest10.com
 # regular expression
 regexp:(^|\.)dualstack\.apiproxy-.+\.amazonaws\.com$
 regexp:(^|\.)dualstack\.ichnaea-web-.+\.amazonaws\.com$
+regexp:(^|\.)apiproxy-device-prod-nlb-.+\.amazonaws\.com$
+regexp:(^|\.)apiproxy-website-nlb-prod-.+\.amazonaws\.com$
 
 # Full
 full:netflix.com.edgesuite.net

--- a/data/netflix
+++ b/data/netflix
@@ -24,10 +24,10 @@ netflixdnstest9.com
 netflixdnstest10.com
 
 # regular expression
-regexp:(^|\.)dualstack\.apiproxy-.+\.amazonaws\.com$
-regexp:(^|\.)dualstack\.ichnaea-web-.+\.amazonaws\.com$
 regexp:(^|\.)apiproxy-device-prod-nlb-.+\.amazonaws\.com$
 regexp:(^|\.)apiproxy-website-nlb-prod-.+\.amazonaws\.com$
+regexp:(^|\.)dualstack\.apiproxy-.+\.amazonaws\.com$
+regexp:(^|\.)dualstack\.ichnaea-web-.+\.amazonaws\.com$
 
 # Full
 full:netflix.com.edgesuite.net


### PR DESCRIPTION
其实这个改动应该是之前[PR](https://github.com/v2fly/domain-list-community/pull/964)的延续，netflix似乎修改了或者增加了设备/区域检测的域名，抓包发现的域名格式格式如下：

```
apiproxy-device-prod-nlb-1-54e80724f8c6ba2d.elb.us-west-2.amazonaws.com:443
apiproxy-website-nlb-prod-3-ac110f6ae472b85a.elb.eu-west-1.amazonaws.com:443
apiproxy-device-prod-nlb-3-a653f8a785200e05.elb.us-west-2.amazonaws.com:443
apiproxy-device-prod-nlb-2-9a34ae4608b5939d.elb.us-west-2.amazonaws.com:443
```

在[其他规则集](https://github.com/ACL4SSR/ACL4SSR/blob/master/Clash/Providers/Ruleset/Netflix.yaml)中也发现了类似的规则增加。

参考之前的规则补充了正则规则：
regexp:(^|\.)apiproxy-device-prod-nlb-.+\.amazonaws\.com$
regexp:(^|\.)apiproxy-website-nlb-prod-.+\.amazonaws\.com$

实际在一台香港机器使用台湾解锁机分流NF(geosite:netflix分流到tw机器)的情况下测试，如果不增加这些规则，登录时还是会跳转到hk站点，并且导致提示密码错误(NF区域风控的问题)，增加规则之后就正确跳转到tw区域了。

另外有个问题请教一下，这个正则规则似乎没法直接写在config文件里？解析的时候总是报错，我从文档里抄了几个确定正确，以及自己写了几个极其简单的正则表达式，放到配置文件里好像也会解析失败。
我尝试在config中写的格式如下：
```
            {
                "domains":
                [
                    "geosite:netflix",
                    "regexp:(^|\.)apiproxy-device-prod-nlb-.+\.amazonaws\.com$",
                ],
                "outboundTag": "NF",
                "type": "field"
            },
```

现在用的是v5版本的程序，但配置格式是v4的，搜了下core那边好像regexp这个规则现在有点乱，也很少看到其他地方有人用regexp。
但是我把这个repo download下来在本地修改编译dlc.dat之后，上传到服务器上覆盖倒是可以正常运行的，也验证了我添加的这两个规则的有效。

只是不清楚要怎么才能在不编译dlc.dat的情况下，直接在config.json中写正则rule才能不报错呢?