### PR TITLE
Update globalsign

### DIFF
--- a/data/globalsign
+++ b/data/globalsign
@@ -1,9 +1,11 @@
-alphassl.com
+alphassl.com @cn
+easy-signing.com @cn
 globalsign-media.com
 globalsign.be
 globalsign.ch
+globalsign.cn @cn
 globalsign.co.uk
-globalsign.com
+globalsign.com @cn
 globalsign.com.au
 globalsign.com.br
 globalsign.com.hk
@@ -13,11 +15,6 @@ globalsign.eu
 globalsign.fr
 globalsign.net
 globalsign.nl
+globalsigncdn.com @cn
 
-full:crl.alphassl.com @cn
-full:crl2.alphassl.com @cn
-full:global.prd.cdn.globalsign.com @cn
-full:ocsp.globalsign.com @cn
-full:ocsp2.globalsign.com @cn
-full:secure.globalsign.com @cn
-full:secure2.alphassl.com @cn
+full:cdn.globalsigncdn.com.cdn.cloudflare.net @cn


### PR DESCRIPTION
添加了一些有中国大陆CDN 的域名, 为 alphassl.com 和 globalsign.com 添加了 `@cn` attr 并移除了 `full:` 完整域名

他们的备案号为: 沪ICP备08025378号