### PR TITLE
remove yamibo from geolocation-cn

### DIFF
--- a/data/category-forums
+++ b/data/category-forums
@@ -12,7 +12,7 @@ include:pixnet
 include:ptt
 include:quora
 include:reddit
-include: yamibo
+include:yamibo
 
 18p2p.com
 avsforum.com

--- a/data/category-forums
+++ b/data/category-forums
@@ -12,6 +12,7 @@ include:pixnet
 include:ptt
 include:quora
 include:reddit
+include: yamibo
 
 18p2p.com
 avsforum.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -124,7 +124,6 @@ include:vgtime
 include:xd
 include:xiaohongshu
 include:ximalaya
-include:yamibo
 include:youku
 include:yy
 include:zhanqi


### PR DESCRIPTION
The website has been switched to use Cloudflare CDN due to a DDoS attack