### PR TITLE
category-games: add fitgirl-repacks.site

### DIFF
--- a/data/category-games
+++ b/data/category-games
@@ -32,6 +32,7 @@ include:xbox
 include:ynoproject
 
 fanatical.com
+fitgirl-repacks.site
 humblebundle.com
 loverslab.com
 modrinth.com


### PR DESCRIPTION
FitGirl Repacks is a website distributing pirated video games.