### PR TITLE
Move cnbeta from category-media-cn to category-media

### DIFF
--- a/data/category-media
+++ b/data/category-media
@@ -13,6 +13,7 @@ include:c-span
 include:cabletv
 include:cbs
 include:cnbc
+include:cnbeta
 include:cnn
 include:dailymail
 include:dw

--- a/data/category-media-cn
+++ b/data/category-media-cn
@@ -1,7 +1,6 @@
 include:36kr
 include:cctv
 include:chinanews
-include:cnbeta
 include:dgtle
 include:geekpark
 include:hupu


### PR DESCRIPTION
用大陆ip访问cnbeta的任意页面都会被跳转到 [https://www.msn.cn/zh-cn/community/channel/vid-yigrey3aqwvu8msgcwqkicf3gvj43va4rtcwf4wgrgici2gi2eps](https://www.msn.cn/zh-cn/channel/source/cnBeta.COM/sr-vid-yigrey3aqwvu8msgcwqkicf3gvj43va4rtcwf4wgrgici2gi2eps) 导致打不开文章