### PR TITLE
Fix facebook

### DIFF
--- a/data/facebook
+++ b/data/facebook
@@ -1,5 +1,3 @@
-include:facebook-ads
-
 aboutfacebook.com
 accessfacebookfromschool.com
 acebooik.com


### PR DESCRIPTION
`facebook-ads` was introduced from pull request #2047 , which led to inability to log in facebook, instagram and so on.

According to the source of #2047 , some domains of facebook should NOT be blocked, see [here](https://github.com/hagezi/dns-blocklists?tab=readme-ov-file#closed_book-multi-ultimate---aggressive-protection-).

Instead of reverting pull request #2047 , I suggest exclude `facebook-ads` from `facebook` and keep it separately.