### PR TITLE
Update bing

### DIFF
--- a/data/bing
+++ b/data/bing
@@ -33,6 +33,7 @@ full:location.microsoft.com
 
 cn.bing.com @cn
 cn.bing.net @cn
+cn.mm.bing.net @cn
 ditu.live.com @cn
 full:bj1.api.bing.com @cn
 full:emoi-cncdn.bing.com @cn


### PR DESCRIPTION
Domain "cn.mm.bing.net" has 4 subdomains:

ts1.cn.mm.bing.net
ts2.cn.mm.bing.net
ts3.cn.mm.bing.net
ts4.cn.mm.bing.net

All of them use IPs in China.