### PR TITLE
kakao/naver: add more domains and categorize by subsidiaries

### DIFF
--- a/data/kakao
+++ b/data/kakao
@@ -2,11 +2,14 @@
 
 daum.net
 daumcdn.net
+daumkakao.io
 kakao.com
-kakaotalk.jp
+kakao.co.kr
 kakaocdn.net
 kakaocorp.com
+kakaotalk.jp
 kgslb.com
+onkakao.net
 
 # Subsidiaries
 
@@ -20,6 +23,7 @@ kakaopiccoma.com
 
 kakaobank.com
 kakaobank.io
+kakaobankcontent.com
 
 # Kakao Enterprise
 

--- a/data/kakao
+++ b/data/kakao
@@ -1,4 +1,79 @@
+# Kakao Corp
+
+daum.net
+daumcdn.net
 kakao.com
+kakaotalk.jp
 kakaocdn.net
 kakaocorp.com
-kakaotalk.jp
+kgslb.com
+
+# Subsidiaries
+
+kakao.vc
+kakaobrain.com
+kakaoinvestment.com
+kakaomobility.com
+kakaopiccoma.com
+
+# KakaoBank
+
+kakaobank.com
+kakaobank.io
+
+# Kakao Enterprise
+
+kakaoenterprise.com
+kakaocloud.com
+kakaoilaas.com
+
+# Kakao Entertainment
+
+1thek.com
+antenna.co.kr
+awesomeent.co.kr
+bhent.co.kr
+dolphiners.com
+gleline.com
+istent.co.kr
+jwide.co.kr
+kakaoent.com
+krosspictures.com
+logosfilm.co.kr
+megamon.co.kr
+melon.com
+msoopent.com
+ootbstudio.co.kr
+shownote.com
+starship-ent.com
+stuidok110.com
+vastenm.com
+zipcine.com
+
+# KakaoGames
+
+daumpcbang.com
+kakaogamescorp.com
+kakaovx.com
+lionhearts.co.kr
+metabora.io
+sena.co.kr
+
+# Kakao HealthCare
+
+kakaohealthcare.com
+karechat.ai
+pastahealth.com
+
+# Kakao Pay
+
+kakaopay.com
+kakaopaysec.com
+kpinsurances.com
+
+# KakaoStyle
+
+fashionbykakao.com
+kakaostyle.com
+posty.kr
+zigzag.kr

--- a/data/naver
+++ b/data/naver
@@ -1,10 +1,45 @@
 include:line
 
-grafolio.com
+# Naver Corp.
+
 naver.com
-naver.jp
+naver.me
 naver.net
 navercorp.com
-plug.game
 pstatic.net
+
+# Naver Cloud
+
+clova.ai
+navercloudcorp.com
+ncloud.com
+worksmobile.com
+
+# Naver Financial
+
+naverfincorp.com
+
+# Snow
+
+snow.me
+snowcorp.com
+vday.io
+
+# Webtoons Corp
+
+studiolico.com
+studioncorp.com
+wattpad.com
 webtoons.com
+webtoonscorp.com
+
+
+# Other Services and Subsidiaries
+
+band.us
+grafolio.com
+modoo.at
+naver.jp
+naverlabs.com
+plug.game
+prismlive.com

--- a/data/naver
+++ b/data/naver
@@ -5,13 +5,16 @@ include:line
 naver.com
 naver.me
 naver.net
+naver.com.akadns.net
 navercorp.com
+nheos.com
 pstatic.net
 
 # Naver Cloud
 
 clova.ai
 navercloudcorp.com
+naverncp.com
 ncloud.com
 worksmobile.com
 
@@ -33,13 +36,14 @@ wattpad.com
 webtoons.com
 webtoonscorp.com
 
-
 # Other Services and Subsidiaries
 
 band.us
 grafolio.com
 modoo.at
 naver.jp
+naverads.com
+naverads.com.akadns.net
 naverlabs.com
 plug.game
 prismlive.com


### PR DESCRIPTION
Looked through below `sources` and wandered through list of subsidiaries to find out subsidiaries.

Both of them have services which are located in `(kakao|naver).com` but in fact operated by subsidiaries[^1]; they are skipped for now.

Sources:
 - kakao: https://www.kakaocorp.com/page/about/subsidiaryCompany
 - naver: https://www.navercorp.com/service/serviceAll

[^1]: ie. `pay.naver.com` is in `naver.com` but in fact run by `Naver Financial`. `page.kakao.com` is in `kakao.com` but in fact run by `Kakao Entertainment`. (Also notably, almost all kakao resources are using shared CDN `kakaocdn.net`, or `kgslb.com`, so for those two, there's no meaning distinguishing them.)