### PR TITLE
Add testipv6.cn to geolocation-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1240,6 +1240,7 @@ tanx.com
 tao123.com
 taoche.com
 te5.com
+testipv6.cn
 tenxcloud.com
 tianjimedia.com
 tianjin-air.com


### PR DESCRIPTION
This pull request adds domain name `testipv6.cn` to geolocation-cn. `testipv6.cn` is a mirror site of `test-ipv6.com` in mainland China.