### PR TITLE
Remove `rfchost.com` from geolocation-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1165,7 +1165,6 @@ qunar.com
 qunarzz.com
 qunjielong.com # 桂ICP备14006138号-2
 qyer.com
-rfchost.com
 rockyenglish.com
 rong360.com
 rtbasia.com


### PR DESCRIPTION
This domain do has a ICP number, but doesn't have any server in Mainland China.