### PR TITLE
Remove btcfans.com from geolocation-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -625,7 +625,6 @@ bobo.com
 bojianger.com
 bokecc.com
 boosj.com
-btcfans.com
 btgtravel.com
 bthhotels.com
 btime.com


### PR DESCRIPTION
1. The site is using Cloudflare CDN.
2. It has been hijacked in China.