### PR TITLE
Split private domain list

### DIFF
--- a/data/connectivity-check
+++ b/data/connectivity-check
@@ -1,0 +1,27 @@
+# ArchLinux
+ping.archlinux.org
+
+# Apple
+captive.apple.com
+
+# Android
+connectivitycheck.gstatic.com
+
+# Cloudflare
+cp.cloudflare.com
+
+# Debian
+network-test.debian.org
+
+# Firefox
+detectportal.firefox.com
+
+# KDE
+networkcheck.kde.org
+
+# MIUI
+full:connect.rom.miui.com
+
+# Windows
+msftconnecttest.com
+msftncsi.com

--- a/data/mozilla
+++ b/data/mozilla
@@ -22,3 +22,9 @@ seamonkey-project.org
 
 # Thunderbird
 thunderbird.net
+
+# Mozilla Location Service
+location.services.mozilla.com
+
+# Mozilla Push Service
+push.services.mozilla.com

--- a/data/private
+++ b/data/private
@@ -122,18 +122,9 @@ d.f.ip6.arpa
 # Dotless domains
 regexp:^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
 
-# ArchLinux
-ping.archlinux.org
-
 # Aruba router
 full:instant.arubanetworks.com
 full:setmeup.arubanetworks.com
-
-# Apple
-captive.apple.com
-
-# Android
-connectivitycheck.gstatic.com
 
 # ASUS router
 # Reference: https://www.asus.com/support/FAQ/1005263/
@@ -141,27 +132,9 @@ full:asusrouter.com
 full:router.asus.com
 full:www.asusrouter.com
 
-# Cloudflare
-cp.cloudflare.com
-
-# Firefox
-detectportal.firefox.com
-
 # H3C
 # https://wwwsg.h3c.com/cn/d_202007/1316557_30005_0.htm#_Toc46214911
 full:oasisauth.h3c.com
-
-# KDE
-networkcheck.kde.org
-
-# MIUI
-full:connect.rom.miui.com
-
-# Mozilla Location Service
-location.services.mozilla.com
-
-# Mozilla Push Service
-push.services.mozilla.com
 
 # Netgear router
 # Reference: https://kb.netgear.com/27199/I-can-t-access-my-router-what-do-I-do
@@ -195,10 +168,6 @@ tendawifi.com
 # Reference: https://resource.tp-link.com.cn/m/productClass/product_document?id=1655112502304621
 tplinkwifi.net
 full:tplogin.cn
-
-# Windows
-msftconnecttest.com
-msftncsi.com
 
 # Xiaomi router
 # Reference: https://www1.miwifi.com/miwifi_faq.html


### PR DESCRIPTION
Currently the private list consists of there different kinds of domains:
- **Domains reserved for local network**, for example 'miwifi.com' and domains defined by RFC6762.
  These domains should be resolved locally or are resolved to local addresses and usually do not work well with fake-ip.
- **Domains defined by OS or applications for connectivity checking purpose**, such as 'msftconnecttest.com'.
  These domains are fine with fake-ip since captive portal detections are implemented with HTTP requests and domains are resolved to public addresses.
- Others like 'push.services.mozilla.com'.
  The reason of being added remains unknown.

This PR splits domains into different lists:
- Reserved local domains remain untouched.
- Connectivity checking domains are moved into separate list, connectivity-check.
- Others are moved back to service providers' list for now.

And appends Debian connectivity check service to connectivity-check list.
(ref: https://salsa.debian.org/utopia-team/network-manager/-/blob/b944168515fa1bef3fcd80895b2122f003605a08/debian/20-connectivity-debian.conf#L2)
