### PR TITLE
Update ctrip

### DIFF
--- a/data/ctrip
+++ b/data/ctrip
@@ -25,5 +25,5 @@ tieyou.com
 toptown.cn
 toursbms.com
 trip.com @!cn
-tripcdn.com
+tripcdn.com @!cn
 vipdlt.com


### PR DESCRIPTION
Trip.com's main service areas are outside mainland China, and its CDN domain name does not have a mainland China node, such as "ak-s.tripcdn.com".