### PR TITLE
Update deno

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -79,6 +79,7 @@ clojure.org
 cnpmjs.org
 cygwin.com
 cython.org
+deno.com
 deno.land
 dev.to
 elixir-lang.org


### PR DESCRIPTION
URLs under deno.land now redirects to deno.com