### PR TITLE
Request for adding aamgame into geolocation-cn

### DIFF
--- a/data/aamgame
+++ b/data/aamgame
@@ -1,0 +1,9 @@
+# 广州市艾美娱乐设备有限公司
+# 粤ICP备09210476号
+aamgame.net
+aamgame.com
+aamgame.mobi
+aamsmart.com
+
+# 舞推 (E舞成名)
+singworld.net

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -294,6 +294,9 @@ guoxuedashi.com
 guoxuemi.com
 mojidict.com
 
+# 街机
+include:aamgame
+
 # Others
 include:8btc
 include:jibencaozuo


### PR DESCRIPTION
# Request for adding aamgame into geolocation-cn
## Changes
- Add `data/aamgame`
- Add `include:aamgame` into `data/geolocation-cn`
## Reason
1. AAMGame is an arcade platform website in the Mainland China.
1. The singworld.net provides their WeChat Official Accounts services, which site is not available outside of China.