### PR TITLE
Add metabrainz

### DIFF
--- a/data/category-orgs
+++ b/data/category-orgs
@@ -6,6 +6,7 @@ include:csis
 include:emojipedia
 include:f-droid
 include:ieee
+include:metabrainz
 include:nist
 include:openstreetmap
 include:paskoocheh

--- a/data/metabrainz
+++ b/data/metabrainz
@@ -1,0 +1,8 @@
+acousticbrainz.org
+bookbrainz.org
+coverartarchive.org
+critiquebrainz.org
+listenbrainz.org
+messybrainz.org
+metabrainz.org
+musicbrainz.org


### PR DESCRIPTION
From their [about](https://metabrainz.org/about) page:

> The MetaBrainz Foundation is a global community creating and maintaining an open encyclopedia of music and arts metadata.

Their projects: [MetaBrainz Projects](https://metabrainz.org/projects).