### PR TITLE
Add GitHub1s

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -21,6 +21,7 @@ include:fontawesome
 include:gemfury
 include:gitbook
 include:github
+include:github1s
 include:gitlab
 include:golang
 include:hashicorp

--- a/data/github1s
+++ b/data/github1s
@@ -1,0 +1,2 @@
+github1s.com
+sourcegraph.com


### PR DESCRIPTION
GitHub1s can be used to quickly view the contents of a repository on GitHub without pulling the repository locally

For example:
https://github1s.com/v2fly/domain-list-community

It relies on SourceGraph's API for its search functionality, so I've put them together for now, but let me know if you want to split them up.