### PR TITLE
Update google-play

### DIFF
--- a/data/bing
+++ b/data/bing
@@ -14,6 +14,7 @@ bingsandbox.com
 bingvisualsearch.com
 bingworld.com
 bluehatnights.com
+copilot.microsoft.com
 dictate.ms
 flipwithsurface.com
 masalladeloslimites.com

--- a/data/google-play
+++ b/data/google-play
@@ -10,5 +10,7 @@ xn--ngstr-lra8j.com
 # then these domains will be used.
 # 北京 (2x3)、上海 (ni5)、广州 (j5o)
 regexp:^r+[0-9]+(---|\.)sn-(2x3|ni5|j5o)\w{5}\.xn--ngstr-lra8j\.com$ @cn
+# the same but DNS pollution in China mainland.
+regexp:^r+[0-9]+(---|\.)sn-(2x3|ni5|j5o)\w{5}\.googlevideo\.com$ @cn
 
 full:redirector.c.play.google.com @cn

--- a/data/microsoft
+++ b/data/microsoft
@@ -136,6 +136,7 @@ managedmeetingrooms.com
 meetfasttrack.com
 meetyourdevices.com
 mepn.com
+microsoftedgeinsider.com
 microsoft-falcon.io
 microsoft-int.com
 microsoft-ppe.com
@@ -205,6 +206,7 @@ msra.cn @cn
 msturing.org
 msudalosti.com
 mymicrosoft.com
+nelreports.net @ads
 nextechafrica.net
 nxta.org
 o365cn.com @cn

--- a/data/steam
+++ b/data/steam
@@ -76,3 +76,6 @@ full:xz.pphimalayanrt.com @cn
 
 # 蒸汽中国
 steamchina.com @cn
+
+# 数云科技
+gstore.val.manlaxy.com @cn


### PR DESCRIPTION
测试: rr3---sn-j5o7dn7s.googlevideo.com
下载telegram出现了这个，
在国内dns污染解析到国外，在国外dns正常但是因为返回的是国内ip在国外也访问不了googlevideo.com。

用国外dns就能在国内直连访问了。



