### PR TITLE
Update qihoo360

### DIFF
--- a/data/qihoo360
+++ b/data/qihoo360
@@ -1,5 +1,6 @@
 include:75team
 include:qihoo360-ads
+include:starworld
 
 360.cn
 360.com


### PR DESCRIPTION
Qihoo 360 wholly owns Beijing World Star, and domain names such as `360-api.cn` are registered by this company.