### PR TITLE
Update openai

### DIFF
--- a/data/openai
+++ b/data/openai
@@ -1,5 +1,4 @@
 # Main domain
-ai.com
 chatgpt.com
 chat.com
 oaistatic.com


### PR DESCRIPTION
`ai.com` now redirects to deepseek, apparently it doesn't belong to openai.