### PR TITLE
Add haitang

### DIFF
--- a/data/category-porn
+++ b/data/category-porn
@@ -19,6 +19,7 @@ include:ehentai
 include:erolabs
 include:fans66
 include:fansta
+include:haitang
 include:hentaivn
 include:heyzo
 include:hooligapps

--- a/data/haitang
+++ b/data/haitang
@@ -1,0 +1,20 @@
+# 海棠文化線上文學城
+
+haitangbook.com
+haitbook.com
+htlvbooks.com
+htnewbooks.com
+htwhbook.com
+lmbooks.com
+lmebooks.com
+longmabook.com
+longmabookcn.com
+lovehtbooks.com
+lvhtebook.com
+mybookinlm.com
+myhtebook.com
+myhtebooks.com
+myhtlmebook.com
+newhtbook.com
+urhtbooks.com
+  


### PR DESCRIPTION
Haitang is a famous website that provides adult fiction on male homosexual topics in mainland China. (The server is in Taiwan)
Now because the Chinese police have arrested some writers on this website, I have started to pay attention to it.
Now I collected all the domain names on this website and added them to `category-porn`.