### PR TITLE
Update adobe(add adobestats.io)

### DIFF
--- a/data/adobe
+++ b/data/adobe
@@ -139,3 +139,6 @@ sign.new
 
 # Adobe Dynamic Media Delivery
 scene7.com
+
+# Adobe Stats IO
+adobestats.io


### PR DESCRIPTION
最近发现新版本的Adobe Photoshop等软件会联系 "*.adobestats.io" ，希望将该域名加入 "adobe" 分类中。

Translate with ChatGPT:
It was recently discovered that new versions of Adobe Photoshop and other software connect to "*.adobestats.io". 
We would like to request that this domain be added to the "adobe" category.