### PR TITLE
Update category-game-accelerator-cn

### DIFF
--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -14,3 +14,4 @@ golinkcn.com
 
 # Watt Toolkit 苏ICP备2023005487号-1
 steampp.net
+rmbgame.net

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -9,3 +9,4 @@ jiasu.bohe.com # 鄂ICP备18023477号-1
 
 # GoLink 加速器
 golink.com
+golinkapi.com

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -10,3 +10,4 @@ jiasu.bohe.com # 鄂ICP备18023477号-1
 # GoLink 加速器
 golink.com
 golinkapi.com
+golinkcn.com

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -15,3 +15,6 @@ golinkcn.com
 # Watt Toolkit 苏ICP备2023005487号-1
 steampp.net
 rmbgame.net
+
+# Steamcommunity 302
+steam302.xyz

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -7,7 +7,7 @@ xunyou.com # 蜀ICP备07504248号-4
 bohejiasuqi.com
 jiasu.bohe.com # 鄂ICP备18023477号-1 
 
-# GoLink 加速器
+# GoLink 加速器 苏ICP备18014251号-2
 golink.com
 golinkapi.com
 golinkcn.com

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -6,3 +6,6 @@ xunyou.com # 蜀ICP备07504248号-4
 # 薄荷加速器
 bohejiasuqi.com
 jiasu.bohe.com # 鄂ICP备18023477号-1 
+
+# GoLink 加速器
+golink.com

--- a/data/category-game-accelerator-cn
+++ b/data/category-game-accelerator-cn
@@ -11,3 +11,6 @@ jiasu.bohe.com # 鄂ICP备18023477号-1
 golink.com
 golinkapi.com
 golinkcn.com
+
+# Watt Toolkit 苏ICP备2023005487号-1
+steampp.net


### PR DESCRIPTION
Add some domain names of game accelerators used in mainland China.
These domains should be directly accessed. I think they should be added to category-game-accelerator-cn.

1. Add the domain name of `GoLink` game accelerator.
2. Add the domain name of Steam acceleration tool `Watt Toolkit`.
3. Add the domain name of Steam acceleration tool `Steamcommunity 302`.