### PR TITLE
Update category-ai-!cn

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -16,9 +16,9 @@ jasper.ai
 notebooklm.google
 notebooklm.google.com
 
+chutes.ai
 dify.ai
 gateway.ai.cloudflare.com
 meta.ai
 openart.ai
 openrouter.ai
-chutes.ai

--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -21,3 +21,4 @@ gateway.ai.cloudflare.com
 meta.ai
 openart.ai
 openrouter.ai
+chutes.ai


### PR DESCRIPTION
Add chutes.ai

chutes.ai is one of the common upstream providers of openrouter.ai