### PR TITLE
Update category-ai-!cn: Add mistral.ai

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -21,3 +21,4 @@ gateway.ai.cloudflare.com
 meta.ai
 openart.ai
 openrouter.ai
+mistral.ai

--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -19,6 +19,6 @@ notebooklm.google.com
 dify.ai
 gateway.ai.cloudflare.com
 meta.ai
+mistral.ai
 openart.ai
 openrouter.ai
-mistral.ai


### PR DESCRIPTION
Mistral is not well-known globally, but many large government enterprises in Europe collaborate with it.
It's not a fly-by-night small company, so it should be included