### PR TITLE
Create category-game-platforms-download

### DIFF
--- a/data/category-game-platforms-download
+++ b/data/category-game-platforms-download
@@ -1,0 +1,542 @@
+# Bethesda - 客户端更新/游戏及 MOD 下载
+full:104.98.3.25 download.cdp.bethesda.net
+full:104.98.3.25 content.cdp.bethesda.net
+
+# Roti - 游戏更新/下载
+full:gamedownloads-rockstargames-com.akamaized.net
+full:lol.secure.dyn.riotcdn.net
+full:ks-foundation.secure.dyn.riotcdn.net
+full:riot-client.secure.dyn.riotcdn.net
+full:mock-game.secure.dyn.riotcdn.net
+full:valorant.secure.dyn.riotcdn.net
+full:wildrift.secure.dyn.riotcdn.net
+full:ares.secure.dyn.riotcdn.net
+full:bacon.secure.dyn.riotcdn.net
+full:ritoplus.secure.dyn.riotcdn.net
+full:wildrift.dyn.riotcdn.net
+full:lol.dyn.riotcdn.net
+full:dyn.riotcdn.net
+full:valorant.dyn.riotcdn.net
+full:global.dyn.riotcdn.net
+full:mock-game.dyn.riotcdn.net
+full:ks-foundation.dyn.riotcdn.net
+full:riot-client.dyn.riotcdn.net
+
+# Rockstar Launcher - 客户端更新/游戏更新/下载
+full:gamedownloads-rockstargames-com.akamaized.net
+
+# Epic Games - 游戏下载[Azamon]
+full:download.epicgames.com
+full:download2.epicgames.com
+full:download3.epicgames.com
+full:download4.epicgames.com
+
+# Epic Games - 游戏下载[Akamai]
+full:epicgames-download1.akamaized.net
+
+# Epic Game - 游戏下载[Fastly]
+full:fastly-download.epicgames.com
+
+# Epic Game - 游戏下载[CloudFlare]
+full:cloudflare.epicgamescdn.com
+
+# Epic Game - 游戏下载[中国区]
+full:epicgames-download1-1251447533.file.myqcloud.com @cn
+
+# Battle.net - 战网下载[CloudN]
+full:blizzard.gcdn.cloudn.co.kr
+
+# Battle.net - 战网下载[Akamai]
+full:blzddist1-a.akamaihd.net
+full:blzddistkr1-a.akamaihd.net
+full:level3.blizzard.com
+full:level3.ssl.blizzard.com
+
+# Battle.net - 战网下载[blizzard]
+full:kr.cdn.blizzard.com
+full:us.cdn.blizzard.com
+full:eu.cdn.blizzard.com
+
+# Battle.net - 战网下载[网易国服]
+full:blzdist-phx.necdn.leihuo.netease.com @cn
+full:blzdist-wow.necdn.leihuo.netease.com @cn
+full:blzdist-hs.necdn.leihuo.netease.com @cn
+full:blzdist-di.necdn.leihuo.netease.com @cn
+full:blzdist-ow.necdn.leihuo.netease.com @cn
+
+# GOG - 客户端更新/游戏下载[Akamai]
+full:gog-cdn.akamaized.net
+
+# GOG - 客户端更新/游戏下载[Fastly]
+full:gog-cdn-fastly-cp77.gog.com
+full:gog-cdn-fastly.gog.com
+full:recommendations-api.gog.com
+full:sections.gog.com
+full:galaxy-promos.gog.com
+full:marketing-sections.gog.com
+
+# XBOX/Microsoft Store - 游戏下载(大陆地区)
+full:assets1.xboxlive.cn @cn
+full:assets2.xboxlive.cn @cn
+full:dl.delivery.mp.microsoft.com @cn
+full:tlu.dl.delivery.mp.microsoft.com @cn
+
+# XBOX/Microsoft Store - 游戏下载(国际)
+full:xvcf1.xboxlive.com
+full:xvcf2.xboxlive.com
+full:assets1.xboxlive.com
+full:assets2.xboxlive.com
+
+# Ubisoft Connect(Uplay) - 游戏下载(国际)
+full:uplaypc-s-ubisoft.cdn.ubi.com
+full:uplaypc-s-ubisoft-ww.cdn.ubi.com
+full:ubisoftconnect.cdn.ubi.com
+
+# Ubisoft Connect(Uplay) - 游戏下载(中国大陆地区)
+full:uplaypc-s-ubisoft.cdn.ubionline.com.cn @cn
+
+# EA Desktop - 游戏下载[akamai-CDN]
+full:origin-a.akamaihd.net
+
+# Steam - 游戏下载(中国区)[新流云]
+full:dl.steam.clngaa.com @cn
+
+# Steam - 游戏下载(中国区)[白山云]
+full:st.dl.eccdnx.com @cn
+full:st.dl.bscstorage.net @cn
+full:trts.baishancdnx.cn @cn
+full:st-bak.viv.wanwang.space @cn
+
+# Steam - 游戏下载(中国区)[阿里云]
+full:cdn-ali.content.steamchina.com @cn
+full:xz.pphimalayanrt.com @cn
+full:lv.queniujq.cn @cn
+full:alibaba.cdn.steampipe.steamcontent.com @cn
+
+# Steam - 游戏下载(中国区)[网宿]
+full:cdn-ws.content.steamchina.com @cn
+
+# Steam - 游戏下载(中国区)[腾讯云]
+full:cdn-qc.content.steamchina.com @cn
+
+# Steam - 游戏下载/社区实况直播(非中国下载区)[Valve]
+full:cache10-atl3.steamcontent.com
+full:cache10-fra1.steamcontent.com
+full:cache10-fra2.steamcontent.com
+full:cache10-iad1.steamcontent.com
+full:cache10-lax1.steamcontent.com
+full:cache10-lhr1.steamcontent.com
+full:cache10-ord1.steamcontent.com
+full:cache10-seo1.steamcontent.com
+full:cache10-sgp1.steamcontent.com
+full:cache10-tyo3.steamcontent.com
+full:cache11-fra1.steamcontent.com
+full:cache11-fra2.steamcontent.com
+full:cache11-iad1.steamcontent.com
+full:cache11-lhr1.steamcontent.com
+full:cache11-tyo3.steamcontent.com
+full:cache12-fra1.steamcontent.com
+full:cache12-fra2.steamcontent.com
+full:cache12-iad1.steamcontent.com
+full:cache12-lhr1.steamcontent.com
+full:cache12-tyo3.steamcontent.com
+full:cache13-fra1.steamcontent.com
+full:cache13-fra2.steamcontent.com
+full:cache13-iad1.steamcontent.com
+full:cache13-lhr1.steamcontent.com
+full:cache14-fra1.steamcontent.com
+full:cache14-fra2.steamcontent.com
+full:cache14-iad1.steamcontent.com
+full:cache14-lhr1.steamcontent.com
+full:cache15-fra2.steamcontent.com
+full:cache15-iad1.steamcontent.com
+full:cache15-lhr1.steamcontent.com
+full:cache16-fra2.steamcontent.com
+full:cache16-iad1.steamcontent.com
+full:cache16-lhr1.steamcontent.com
+full:cache1-ams1.steamcontent.com
+full:cache1-atl1.steamcontent.com
+full:cache1-atl3.steamcontent.com
+full:cache1-bom1.steamcontent.com
+full:cache1-bom2.steamcontent.com
+full:cache1-dfw1.steamcontent.com
+full:cache1-eze1.steamcontent.com
+full:cache1-fra1.steamcontent.com
+full:cache1-fra2.steamcontent.com
+full:cache1-gru1.steamcontent.com
+full:cache1-hkg1.steamcontent.com
+full:cache1-iad1.steamcontent.com
+full:cache1-jnb1.steamcontent.com
+full:cache1-lax1.steamcontent.com
+full:cache1-lhr1.steamcontent.com
+full:cache1-maa1.steamcontent.com
+full:cache1-maa2.steamcontent.com
+full:cache1-mad1.steamcontent.com
+full:cache1-ord1.steamcontent.com
+full:cache1-par1.steamcontent.com
+full:cache1-scl1.steamcontent.com
+full:cache1-sea1.steamcontent.com
+full:cache1-seo1.steamcontent.com
+full:cache1-sgp1.steamcontent.com
+full:cache1-sto1.steamcontent.com
+full:cache1-sto2.steamcontent.com
+full:cache1-syd1.steamcontent.com
+full:cache1-tyo3.steamcontent.com
+full:cache1-vie1.steamcontent.com
+full:cache1-waw1.steamcontent.com
+full:cache2-ams1.steamcontent.com
+full:cache2-atl1.steamcontent.com
+full:cache2-atl3.steamcontent.com
+full:cache2-bom2.steamcontent.com
+full:cache2-dfw1.steamcontent.com
+full:cache2-eze1.steamcontent.com
+full:cache2-fra1.steamcontent.com
+full:cache2-fra2.steamcontent.com
+full:cache2-gru1.steamcontent.com
+full:cache2-hkg1.steamcontent.com
+full:cache2-iad1.steamcontent.com
+full:cache2-jnb1.steamcontent.com
+full:cache2-lax1.steamcontent.com
+full:cache2-lhr1.steamcontent.com
+full:cache2-maa2.steamcontent.com
+full:cache2-mad1.steamcontent.com
+full:cache2-ord1.steamcontent.com
+full:cache2-par1.steamcontent.com
+full:cache2-scl1.steamcontent.com
+full:cache2-sea1.steamcontent.com
+full:cache2-seo1.steamcontent.com
+full:cache2-sgp1.steamcontent.com
+full:cache2-sto1.steamcontent.com
+full:cache2-sto2.steamcontent.com
+full:cache2-syd1.steamcontent.com
+full:cache2-tyo3.steamcontent.com
+full:cache2-vie1.steamcontent.com
+full:cache2-waw1.steamcontent.com
+full:cache3-ams1.steamcontent.com
+full:cache3-atl1.steamcontent.com
+full:cache3-atl3.steamcontent.com
+full:cache3-dfw1.steamcontent.com
+full:cache3-dxb1.steamcontent.com
+full:cache3-eze1.steamcontent.com
+full:cache3-fra1.steamcontent.com
+full:cache3-fra2.steamcontent.com
+full:cache3-gru1.steamcontent.com
+full:cache3-hkg1.steamcontent.com
+full:cache3-iad1.steamcontent.com
+full:cache3-jnb1.steamcontent.com
+full:cache3-lax1.steamcontent.com
+full:cache3-lhr1.steamcontent.com
+full:cache3-lim1.steamcontent.com
+full:cache3-mad1.steamcontent.com
+full:cache3-ord1.steamcontent.com
+full:cache3-par1.steamcontent.com
+full:cache3-scl1.steamcontent.com
+full:cache3-sea1.steamcontent.com
+full:cache3-seo1.steamcontent.com
+full:cache3-sgp1.steamcontent.com
+full:cache3-sto1.steamcontent.com
+full:cache3-sto2.steamcontent.com
+full:cache3-syd1.steamcontent.com
+full:cache3-tyo3.steamcontent.com
+full:cache3-vie1.steamcontent.com
+full:cache3-waw1.steamcontent.com
+full:cache4-ams1.steamcontent.com
+full:cache4-atl1.steamcontent.com
+full:cache4-atl3.steamcontent.com
+full:cache4-dfw1.steamcontent.com
+full:cache4-dxb1.steamcontent.com
+full:cache4-eze1.steamcontent.com
+full:cache4-fra1.steamcontent.com
+full:cache4-fra2.steamcontent.com
+full:cache4-gru1.steamcontent.com
+full:cache4-hkg1.steamcontent.com
+full:cache4-iad1.steamcontent.com
+full:cache4-jnb1.steamcontent.com
+full:cache4-lax1.steamcontent.com
+full:cache4-lhr1.steamcontent.com
+full:cache4-lim1.steamcontent.com
+full:cache4-mad1.steamcontent.com
+full:cache4-ord1.steamcontent.com
+full:cache4-par1.steamcontent.com
+full:cache4-scl1.steamcontent.com
+full:cache4-sea1.steamcontent.com
+full:cache4-seo1.steamcontent.com
+full:cache4-sgp1.steamcontent.com
+full:cache4-sto1.steamcontent.com
+full:cache4-sto2.steamcontent.com
+full:cache4-syd1.steamcontent.com
+full:cache4-tyo3.steamcontent.com
+full:cache4-vie1.steamcontent.com
+full:cache4-waw1.steamcontent.com
+full:cache5-ams1.steamcontent.com
+full:cache5-atl1.steamcontent.com
+full:cache5-atl3.steamcontent.com
+full:cache5-dfw1.steamcontent.com
+full:cache5-fra1.steamcontent.com
+full:cache5-fra2.steamcontent.com
+full:cache5-gru1.steamcontent.com
+full:cache5-hkg1.steamcontent.com
+full:cache5-iad1.steamcontent.com
+full:cache5-lax1.steamcontent.com
+full:cache5-lhr1.steamcontent.com
+full:cache5-mad1.steamcontent.com
+full:cache5-ord1.steamcontent.com
+full:cache5-par1.steamcontent.com
+full:cache5-sea1.steamcontent.com
+full:cache5-seo1.steamcontent.com
+full:cache5-sgp1.steamcontent.com
+full:cache5-sto1.steamcontent.com
+full:cache5-sto2.steamcontent.com
+full:cache5-syd1.steamcontent.com
+full:cache5-tyo3.steamcontent.com
+full:cache5-vie1.steamcontent.com
+full:cache5-waw1.steamcontent.com
+full:cache6-ams1.steamcontent.com
+full:cache6-atl1.steamcontent.com
+full:cache6-atl3.steamcontent.com
+full:cache6-dfw1.steamcontent.com
+full:cache6-fra1.steamcontent.com
+full:cache6-fra2.steamcontent.com
+full:cache6-gru1.steamcontent.com
+full:cache6-hkg1.steamcontent.com
+full:cache6-iad1.steamcontent.com
+full:cache6-lax1.steamcontent.com
+full:cache6-lhr1.steamcontent.com
+full:cache6-mad1.steamcontent.com
+full:cache6-ord1.steamcontent.com
+full:cache6-par1.steamcontent.com
+full:cache6-sea1.steamcontent.com
+full:cache6-seo1.steamcontent.com
+full:cache6-sgp1.steamcontent.com
+full:cache6-sto1.steamcontent.com
+full:cache6-sto2.steamcontent.com
+full:cache6-syd1.steamcontent.com
+full:cache6-tyo3.steamcontent.com
+full:cache6-vie1.steamcontent.com
+full:cache6-waw1.steamcontent.com
+full:cache7-ams1.steamcontent.com
+full:cache7-atl3.steamcontent.com
+full:cache7-dfw1.steamcontent.com
+full:cache7-fra1.steamcontent.com
+full:cache7-fra2.steamcontent.com
+full:cache7-gru1.steamcontent.com
+full:cache7-hkg1.steamcontent.com
+full:cache7-iad1.steamcontent.com
+full:cache7-lax1.steamcontent.com
+full:cache7-lhr1.steamcontent.com
+full:cache7-ord1.steamcontent.com
+full:cache7-par1.steamcontent.com
+full:cache7-seo1.steamcontent.com
+full:cache7-sgp1.steamcontent.com
+full:cache7-sto2.steamcontent.com
+full:cache7-tyo3.steamcontent.com
+full:cache7-vie1.steamcontent.com
+full:cache7-waw1.steamcontent.com
+full:cache8-ams1.steamcontent.com
+full:cache8-atl3.steamcontent.com
+full:cache8-dfw1.steamcontent.com
+full:cache8-fra1.steamcontent.com
+full:cache8-fra2.steamcontent.com
+full:cache8-gru1.steamcontent.com
+full:cache8-hkg1.steamcontent.com
+full:cache8-iad1.steamcontent.com
+full:cache8-lax1.steamcontent.com
+full:cache8-lhr1.steamcontent.com
+full:cache8-ord1.steamcontent.com
+full:cache8-par1.steamcontent.com
+full:cache8-seo1.steamcontent.com
+full:cache8-sgp1.steamcontent.com
+full:cache8-sto2.steamcontent.com
+full:cache8-tyo3.steamcontent.com
+full:cache8-vie1.steamcontent.com
+full:cache8-waw1.steamcontent.com
+full:cache9-atl3.steamcontent.com
+full:cache9-fra1.steamcontent.com
+full:cache9-fra2.steamcontent.com
+full:cache9-iad1.steamcontent.com
+full:cache9-lax1.steamcontent.com
+full:cache9-lhr1.steamcontent.com
+full:cache9-ord1.steamcontent.com
+full:cache9-seo1.steamcontent.com
+full:cache9-sgp1.steamcontent.com
+full:cache9-tyo3.steamcontent.com
+full:cache11-lax1.steamcontent.com
+full:cache12-lax1.steamcontent.com
+full:cache13-lax1.steamcontent.com
+full:cache14-lax1.steamcontent.com
+full:cache15-lax1.steamcontent.com
+full:cache16-lax1.steamcontent.com
+full:cache17-lax1.steamcontent.com
+full:cache18-lax1.steamcontent.com
+full:cache19-lax1.steamcontent.com
+full:cache20-lax1.steamcontent.com
+full:cache21-lax1.steamcontent.com
+full:cache17-iad1.steamcontent.com
+full:cache18-iad1.steamcontent.com
+full:cache19-iad1.steamcontent.com
+full:cache20-iad1.steamcontent.com
+full:cache21-iad1.steamcontent.com
+full:cache22-iad1.steamcontent.com
+full:cache23-iad1.steamcontent.com
+full:cache24-iad1.steamcontent.com
+full:cache25-iad1.steamcontent.com
+full:cache26-iad1.steamcontent.com
+full:cache27-iad1.steamcontent.com
+full:cache28-iad1.steamcontent.com
+full:cache15-fra1.steamcontent.com
+full:cache16-fra1.steamcontent.com
+full:cache21-fra1.steamcontent.com
+full:cache22-fra1.steamcontent.com
+full:cache23-fra1.steamcontent.com
+full:cache24-fra1.steamcontent.com
+full:cache25-fra1.steamcontent.com
+full:cache26-fra1.steamcontent.com
+full:cache27-fra1.steamcontent.com
+full:cache28-fra1.steamcontent.com
+full:cache29-fra1.steamcontent.com
+full:cache30-fra1.steamcontent.com
+full:cache31-fra1.steamcontent.com
+full:cache32-fra1.steamcontent.com
+full:cache33-fra1.steamcontent.com
+full:cache34-fra1.steamcontent.com
+full:cache35-fra1.steamcontent.com
+full:cache36-fra1.steamcontent.com
+full:cache37-fra1.steamcontent.com
+full:cache38-fra1.steamcontent.com
+full:cache39-fra1.steamcontent.com
+full:cache40-fra1.steamcontent.com
+full:cache41-fra1.steamcontent.com
+full:cache42-fra1.steamcontent.com
+full:cache43-fra1.steamcontent.com
+full:cache44-fra1.steamcontent.com
+full:cache45-fra1.steamcontent.com
+full:cache46-fra1.steamcontent.com
+full:cache47-fra1.steamcontent.com
+full:cache48-fra1.steamcontent.com
+full:cache49-fra1.steamcontent.com
+full:cache50-fra1.steamcontent.com
+full:cache51-fra1.steamcontent.com
+full:cache52-fra1.steamcontent.com
+full:cache53-fra1.steamcontent.com
+full:cache54-fra1.steamcontent.com
+full:cache55-fra1.steamcontent.com
+full:cache56-fra1.steamcontent.com
+full:cache57-fra1.steamcontent.com
+full:cache58-fra1.steamcontent.com
+full:cache59-fra1.steamcontent.com
+full:cache61-fra1.steamcontent.com
+full:cache62-fra1.steamcontent.com
+full:cache63-fra1.steamcontent.com
+full:cache64-fra1.steamcontent.com
+full:cache65-fra1.steamcontent.com
+full:cache66-fra1.steamcontent.com
+full:cache67-fra1.steamcontent.com
+full:cache68-fra1.steamcontent.com
+full:cache69-fra1.steamcontent.com
+full:cache7-atl1.steamcontent.com
+full:cache8-atl1.steamcontent.com
+full:cache9-atl1.steamcontent.com
+full:cache10-atl1.steamcontent.com
+full:cache11-atl1.steamcontent.com
+full:cache7-sto1.steamcontent.com
+full:cache8-sto1.steamcontent.com
+full:cache9-sto1.steamcontent.com
+full:cache10-sto1.steamcontent.com
+full:cache11-ord1.steamcontent.com
+full:cache12-ord1.steamcontent.com
+full:cache13-ord1.steamcontent.com
+full:cache14-ord1.steamcontent.com
+full:cache15-ord1.steamcontent.com
+full:cache16-ord1.steamcontent.com
+full:cache17-ord1.steamcontent.com
+full:cache18-ord1.steamcontent.com
+full:cache19-ord1.steamcontent.com
+full:cache20-ord1.steamcontent.com
+full:cache1-man1.steamcontent.com
+full:cache2-man1.steamcontent.com
+full:cache8-sea1.steamcontent.com
+full:cache10-sea1.steamcontent.com
+full:cache11-sea1.steamcontent.com
+full:cache12-sea1.steamcontent.com
+full:cache19-lhr1.steamcontent.com
+full:cache20-lhr1.steamcontent.com
+full:cache21-lhr1.steamcontent.com
+full:cache22-lhr1.steamcontent.com
+full:cache23-lhr1.steamcontent.com
+full:cache24-lhr1.steamcontent.com
+full:cache25-lhr1.steamcontent.com
+full:cache26-lhr1.steamcontent.com
+full:cache27-lhr1.steamcontent.com
+full:cache28-lhr1.steamcontent.com
+full:cache29-lhr1.steamcontent.com
+full:cache30-lhr1.steamcontent.com
+full:cache31-lhr1.steamcontent.com
+full:cache32-lhr1.steamcontent.com
+full:cache33-lhr1.steamcontent.com
+full:cache34-lhr1.steamcontent.com
+full:cache35-lhr1.steamcontent.com
+full:cache1-tyo1.steamcontent.com
+full:cache2-tyo1.steamcontent.com
+full:cache1-tyo2.steamcontent.com
+full:cache2-tyo2.steamcontent.com
+full:cache3-tyo2.steamcontent.com
+full:cache4-tyo2.steamcontent.com
+full:cache9-ams1.steamcontent.com
+full:cache10-ams1.steamcontent.com
+full:cache11-ams1.steamcontent.com
+full:cache12-ams1.steamcontent.com
+full:cache13-ams1.steamcontent.com
+full:cache14-ams1.steamcontent.com
+full:cache15-ams1.steamcontent.com
+full:cache16-ams1.steamcontent.com
+full:cache17-ams1.steamcontent.com
+full:cache18-ams1.steamcontent.com
+full:cache11-sgp1.steamcontent.com
+full:cache12-sgp1.steamcontent.com
+full:cache1-okc1.steamcontent.com
+full:cache2-okc1.steamcontent.com
+full:cache3-okc1.steamcontent.com
+full:cache4-okc1.steamcontent.com
+full:cache5-okc1.steamcontent.com
+full:cache6-okc1.steamcontent.com
+full:cache7-okc1.steamcontent.com
+full:cache8-okc1.steamcontent.com
+full:cache9-vie1.steamcontent.com
+full:cache10-vie1.steamcontent.com
+full:cache11-vie1.steamcontent.com
+full:cache12-vie1.steamcontent.com
+full:cache9-sto2.steamcontent.com
+full:cache10-sto2.steamcontent.com
+full:cache1-lim1.steamcontent.com
+full:cache2-lim1.steamcontent.com
+full:cache1-dxb1.steamcontent.com
+full:cache2-dxb1.steamcontent.com
+full:cache10-gru1.steamcontent.com
+full:cache12-atl1.steamcontent.com
+full:cache13-atl1.steamcontent.com
+full:cache17-fra1.steamcontent.com
+full:cache18-fra1.steamcontent.com
+full:cache19-fra1.steamcontent.com
+full:cache20-fra1.steamcontent.com
+full:cache3-tyo1.steamcontent.com
+full:cache4-tyo1.steamcontent.com
+full:cache5-tyo1.steamcontent.com
+full:cache6-tyo1.steamcontent.com
+full:cache9-gru1.steamcontent.com
+
+# Steam - 游戏下载(非中国下载区)[akamai]
+full:steampipe.akamaized.net
+full:steampipe-kr.akamaized.net
+full:steampipe-partner.akamaized.net
+full:akamai.cdn.steampipe.steamcontent.com
+
+# Steam - 游戏下载(非中国下载区)[Fastly]
+full:fastly.cdn.steampipe.steamcontent.com
+
+# Steam - 游戏下载(非中国下载区)[网宿(国际)]
+full:steam.eca.qtlglb.com
+full:steam.naeu.qtlglb.com
+full:steam.ru.qtlglb.com
+
+# Steam - 游戏下载(非中国下载区)[edgecast]
+full:edge.steam-dns.top.comcast.net


### PR DESCRIPTION
Create a category that contains the download CDN domains of many well-known game platforms, such as Steam, Epic Games, Battle.net, and EA Desktop, etc.

***

Users can use this category and `category-game` at the same time, and place `category-game-platforms-download` before `category-game`.

In this way, users can achieve the following functions: `PROXY` access to the game platform and `DIRECT` access to the game download CDN at the same time.

***

The domains in category are collected from the hosts tool `UsbEAm Hosts Editor V4.0.1`.

Maybe there are more game platform download CDN domains that are not included. 

I will update this category regularly and add as many game platform download CDN domains as possible.  

***

PS:
I did not use `regexp:` but `full:` for the following reasons:
1. To match CDN domains more accurately
2. Other contributors can add or delete domain names more easily in the future
