### PR TITLE
Update apple 新增Apple Health Studies域名

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -478,6 +478,9 @@ appleone.website
 # Shazam
 shazam.com
 
+# Apple Health Studies
+ingest.apple-studies.com # 采集心率、运动、听力等传感器数据，以及用户填报的研究问卷，将其加密后上传至 Apple 后端
+
 # Others
 1to1computing.com.au
 1to1conference.com.au


### PR DESCRIPTION
此域名隶属苹果Apple Health Studies项目的Research 应用，负责上传用户填写的问卷，传感器收集数据到苹果后端，以参与合作大学的公卫项目