### PR TITLE
Update bingAI相关域名

### DIFF
--- a/data/bing
+++ b/data/bing
@@ -2,9 +2,9 @@
 bing
 
 # BingAI，Copilot
-full:copilot.microsoft.com # 微软个人账户Copilot，可在Windows任务栏/浏览器侧边栏启动
-full:copilot.cloud.microsoft # 微软企业/组织Copilot，个人账号无法使用
-#full:www.bing.com # 网页搜索AI，与搜索共用域名
+full:copilot.microsoft.com @copilot # 微软个人账户Copilot，可在Windows任务栏/浏览器侧边栏启动
+full:copilot.cloud.microsoft @copilot # 微软企业/组织Copilot，个人账号无法使用
+full:www.bing.com @copilot # 网页搜索AI，与搜索共用域名
 
 bing.com
 bing.com.cn @cn


### PR DESCRIPTION
1.新增企业/组织AI域名，为个人AI域名添加注释并整理归类
2.常规搜索AI由于与bing搜索共用域名，只以location区分，我不确定添加一条给ai这样做是否利于使用，如果不确定性太大可以删除
3.为ai域名添加ai属性，以便使用geosite:bing@copilot来仅代理AI相关域名而让其他bing服务直连

不知道是否接受这种AI属性分类，不太符合规范的话就删掉吧🫡