### PR TITLE
Add Alimama domain to alibaba-ads

### DIFF
--- a/data/alibaba-ads
+++ b/data/alibaba-ads
@@ -96,3 +96,4 @@ v6-adashx.ut.ele.me @ads
 v6-adashx.ut.taobao.com @ads
 w.m.taobao.com @ads
 yiliao.hupan.com @ads
+cdn-mum.alibabachengdun.com @ads

--- a/data/alibaba-ads
+++ b/data/alibaba-ads
@@ -28,6 +28,7 @@ atanx.alicdn.com @ads
 atanx2.alicdn.com @ads
 c-adash.m.taobao.com @ads
 cdn0.mobmore.com @ads
+cdn-mum.alibabachengdun.com @ads
 click.aliyun.com @ads
 click.mz.simba.taobao.com @ads
 cm.ipinyou.com @ads
@@ -96,4 +97,4 @@ v6-adashx.ut.ele.me @ads
 v6-adashx.ut.taobao.com @ads
 w.m.taobao.com @ads
 yiliao.hupan.com @ads
-cdn-mum.alibabachengdun.com @ads
+

--- a/data/alibaba-ads
+++ b/data/alibaba-ads
@@ -27,8 +27,8 @@ apoll.m.taobao.com @ads
 atanx.alicdn.com @ads
 atanx2.alicdn.com @ads
 c-adash.m.taobao.com @ads
-cdn0.mobmore.com @ads
 cdn-mum.alibabachengdun.com @ads
+cdn0.mobmore.com @ads
 click.aliyun.com @ads
 click.mz.simba.taobao.com @ads
 cm.ipinyou.com @ads


### PR DESCRIPTION
添加阿里妈妈相关域名，用于部分阿里系应用（如菜鸟 APP、部分支付宝小程序）的广告推荐（目前仅发现这一个）