### PR TITLE
update google-deepmind

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -11,6 +11,7 @@ proactivebackend-pa.googleapis.com
 full:ai.google.dev
 full:alkalicore-pa.clients6.google.com
 full:alkalimakersuite-pa.clients6.google.com
+full:webchannel-alkalimakersuite-pa.clients6.google.com
 generativeai.google
 makersuite.google.com
 


### PR DESCRIPTION
`webchannel-alkalimakersuite-pa.clients6.google.com` is needed by stream realtime in Google AI Studio.