### PR TITLE
sohu-ads: remove data.vod.itc.cn

### DIFF
--- a/data/sohu-ads
+++ b/data/sohu-ads
@@ -2,7 +2,6 @@ adnet.sohu.com @ads
 ads.sohu.com @ads
 adv-sv-show.focus.cn @ads
 aty.sohu.com @ads
-data.vod.itc.cn @ads
 epro.sogou.com @ads
 fpb.sohu.com @ads
 go.sohu.com @ads


### PR DESCRIPTION
Videos on `https://tv.sohu.com/` cannot be loaded when `data.vod.itc.cn` is blocked.

Related issue: https://github.com/privacy-protection-tools/anti-AD/issues/1038