### PR TITLE
Add .internal to the "private" group, and ESET domains 

### DIFF
--- a/data/eset
+++ b/data/eset
@@ -1,0 +1,14 @@
+# ESET Wiki - [KB332] Ports and addresses required to use your ESET product with a third-party firewall
+cn.eset.com @cn
+e5.sk
+eset.com
+eset.eu
+eset.sk
+eset.systems
+esetsoftware.com
+
+# ESET Password Manager
+full:eset-prod-ca48648d0ce7cadf.elb.eu-central-1.amazonaws.com
+
+# Connection between the Agent and ESET PROTECT
+full:epc-de-agent-proxy.germanywestcentral.cloudapp.azure.com

--- a/data/private
+++ b/data/private
@@ -17,6 +17,9 @@ local
 # https://tools.ietf.org/html/rfc8375
 home.arpa
 
+# https://www.icann.org/en/public-comment/proceeding/proposed-top-level-domain-string-for-private-use-24-01-2024
+internal
+
 # References: https://www.iana.org/assignments/locally-served-dns-zones/locally-served-dns-zones.xhtml
 # https://www.rfc-editor.org/rfc/rfc6303.html
 0.in-addr.arpa


### PR DESCRIPTION
1. The Internet Assigned Numbers Authority (IANA) has made a provisional determination that “.INTERNAL” should be reserved for private-use and internal network applications.
2. Add ESET: Malware Protection & Internet Security Domains, [[KB332] Ports and addresses required to use your ESET product with a third-party firewall](https://support.eset.com/en/kb332-ports-and-addresses-required-to-use-your-eset-product-with-a-third-party-firewall)