### PR TITLE
Chore: Optimize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,37 @@
-.idea
-.vscode
+# IDE settings
+.idea/
+.vscode/
 
+# Go build output
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
 /domain-list-community
 /domain-list-community.exe
 
-# Generated dat file.
+# Generated data file
 dlc.dat
 
-# Exported plaintext lists.
-/*.txt
+# Exported plaintext lists (in project root)
+*.txt
+
+# System files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Go vendor directory (if used)
+vendor/
+
+# Binary directory (if used)
+bin/
+
+# Go coverage files
+coverage.out
+
+# Log files
+*.log


### PR DESCRIPTION
Ignored IDE and editor configuration folders (.idea/, .vscode/). 
Added rules to ignore Go build output files and binaries (e.g., *.exe, *.out, *.test). 
Excluded generated data and plaintext export files (dlc.dat, *.txt). 
Added common system files to ignore (.DS_Store, Thumbs.db, Desktop.ini). 
Ignored the vendor/ and bin/ directories, which are commonly generated in Go projects. Added a rule for Go test coverage files (coverage.out) and log files (*.log).