### PR TITLE
Adding a domain for Google Labs

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -27,3 +27,6 @@ notebooklm.google.com
 # Jules
 jules.google
 jules.google.com
+
+# Google AI Labs 
+labs.google


### PR DESCRIPTION
The labs.google domain has been added to the list of domains to support Google Labs services.
This change is necessary for the functionality interacting with Google's experimental AI services hosted on this domain.