### PR TITLE
Adding Google Labs domains

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -30,3 +30,4 @@ jules.google.com
 
 # Google AI Labs 
 labs.google
+aisandbox-pa.googleapis.com

--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -27,3 +27,6 @@ notebooklm.google.com
 # Jules
 jules.google
 jules.google.com
+
+# Google AI Labs 
+labs.google

--- a/data/mailru
+++ b/data/mailru
@@ -1,3 +1,5 @@
+boosty.to
 imgsmail.ru
 mail.ru
 mycdn.me
+okcdn.ru


### PR DESCRIPTION
Domains has been added to the list of domains to support Google Labs services. This change is necessary for the functionality interacting with Google's experimental AI services hosted on this domain.