### PR TITLE
Adding the Boosty domain and Odnoklassniki CDN

### DIFF
--- a/data/mailru
+++ b/data/mailru
@@ -1,3 +1,5 @@
+boosty.to
 imgsmail.ru
 mail.ru
 mycdn.me
+okcdn.ru


### PR DESCRIPTION
Adding the Boosty domain and Odnoklassniki CDN: 
- boosty.to (a Russian platform that enables financial support for content creators, affiliated with VK ecosystem)
- okcdn.ru (Odnoklassniki's CDN, part of the VK/Mail.ru Group infrastructure)