### PR TITLE
Adding the Boosty domain and Odnoklassniki CDN

### DIFF
--- a/data/mailru
+++ b/data/mailru
@@ -1,3 +1,7 @@
+boosty.to
+donationalerts.com
 imgsmail.ru
 mail.ru
+memealerts.com
 mycdn.me
+okcdn.ru


### PR DESCRIPTION
Adding the Boosty domain and Odnoklassniki CDN: 
- boosty.to – a Russian platform that enables financial support for content creators, affiliated with VK ecosystem; owned by MailRu
- okcdn.ru – Odnoklassniki CDN, part of the VK/Mail.ru Group infrastructure; owned by MailRu
- memealerts.com – a service for displaying donations and meme-style alerts on streams, primarily used by streamers on Twitch and YouTube; owned by MailRu
- donationalerts.com – the largest donation and alert platform in the Russian-speaking segment, integrated with VK, Twitch, and other platforms; owned by MailRu