### PR TITLE
fix: googlefcm seems to be partially GFW’ed in China

### DIFF
--- a/data/googlefcm
+++ b/data/googlefcm
@@ -1,12 +1,12 @@
-full:alt1-mtalk.google.com
-full:alt2-mtalk.google.com
-full:alt3-mtalk.google.com
-full:alt4-mtalk.google.com
-full:alt5-mtalk.google.com
-full:alt6-mtalk.google.com
+full:alt1-mtalk.google.com @!cn
+full:alt2-mtalk.google.com @!cn
+full:alt3-mtalk.google.com @!cn
+full:alt4-mtalk.google.com @!cn
+full:alt5-mtalk.google.com @!cn
+full:alt6-mtalk.google.com @!cn
 full:alt7-mtalk.google.com
 full:alt8-mtalk.google.com
 full:mtalk-dev.google.com
 full:mtalk-staging.google.com
-full:mtalk.google.com
+full:mtalk.google.com @!cn
 full:mtalk4.google.com


### PR DESCRIPTION
Refer to: https://t.me/vvb2060Channel/995

> 因此确认为GFW黑洞了mtalk的IP，并且在随机地区(逐步?)拉黑mtalk的SNI。alt域名未拉黑，alt7和8的IP未黑洞。
> 表现出明确的干扰意图，但未完全阻断，FCM可能会在多次失败后切换到alt7和8并恢复正常。