### PR TITLE
Update Nvidia domains with CDN subdomains

### DIFF
--- a/data/nvidia
+++ b/data/nvidia
@@ -61,6 +61,7 @@ tegrazone.jp
 tegrazone.kr
 
 geforce.com.edgesuite.net
+nvidia.com.edgesuite.net
 nvidia.com.edgekey.net
 nvidiagrid.net.edgekey.net
 full:nvidia.tt.omtrdc.net

--- a/data/nvidia
+++ b/data/nvidia
@@ -43,6 +43,7 @@ nvidia.it
 nvidia.jp
 nvidia.lu
 nvidia.mx
+nvidia.net
 nvidia.nl
 nvidia.no
 nvidia.pl
@@ -59,6 +60,9 @@ tegrazone.com
 tegrazone.jp
 tegrazone.kr
 
+geforce.com.edgesuite.net
+nvidia.com.edgekey.net
+nvidiagrid.net.edgekey.net
 full:nvidia.tt.omtrdc.net
 
 # NVIDIA 文件下载服务器中国镜像

--- a/data/nvidia
+++ b/data/nvidia
@@ -43,7 +43,6 @@ nvidia.it
 nvidia.jp
 nvidia.lu
 nvidia.mx
-nvidia.net
 nvidia.nl
 nvidia.no
 nvidia.pl


### PR DESCRIPTION
I've noticed there are connections from Nvidia APP to the following domains, which are CNAMES:
download.gfe.nvidia.com.edgekey.net
ngx.download.nvidia.com.edgekey.net
services.gfe.nvidia.com -> services.gfe.nvidia.com.edgesuite.net
static.nvidiagrid.net -> static.nvidiagrid.net.edgekey.net
ops.gx.nvidia.com.edgesuite.net
origin-gfwsl.gtm.nvidia.net -> gfwsl.geforce.com.edgesuit.net
ota.nvidia.com -> ota.nvidia.com.edgekey.net
www.nvidia.com -> www.nvidia.com.edgekey.net

I believe these are subdomains belonging to nvidia on Microsoft's CDN