### PR TITLE
dji: add robomaster.com

### DIFF
--- a/data/dji
+++ b/data/dji
@@ -5,3 +5,4 @@ djiits.com
 djiops.com
 djiservice.org
 skypixel.com
+robomaster.com


### PR DESCRIPTION
robomaster.com 粤ICP备2022092332号-3 深圳市大疆无人机应用有限公司
该域名是大疆公司举办的全国大学生机器人大赛的网站。
