### PR TITLE
Remove :: and 0.0.0.0 from private

### DIFF
--- a/data/private
+++ b/data/private
@@ -22,7 +22,6 @@ internal
 
 # References: https://www.iana.org/assignments/locally-served-dns-zones/locally-served-dns-zones.xhtml
 # https://www.rfc-editor.org/rfc/rfc6303.html
-0.in-addr.arpa
 2.0.192.in-addr.arpa
 10.in-addr.arpa
 16.172.in-addr.arpa
@@ -47,7 +46,6 @@ internal
 168.192.in-addr.arpa
 254.169.in-addr.arpa
 255.255.255.255.in-addr.arpa
-0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
 8.b.d.0.1.0.0.2.ip6.arpa
 8.e.f.ip6.arpa


### PR DESCRIPTION
Originally posted at https://github.com/MetaCubeX/meta-rules-dat/pull/98, copying to here,

---

Hi, according to section 3 of [IETF RFC 5735](https://datatracker.ietf.org/doc/html/rfc5735#section-3) and [RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122#page-29) 3.2.1.3 (a), addresses in `0.0.0.0/8`,

> MUST NOT be sent, except as a source address as part of an initialization procedure by which the host learns ... IP address.

And according to [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.2) 2.5.2, the `::`,

> must not be used as the destination address of IPv6 packets or in IPv6 Routing headers.

No client in a normal case would even try to request such addresses.

In the real world, the IPv4 address `0.0.0.0` and IPv6 address `::` are used by ISPs and enterprise networks to block access to a specific domain on the DNS level. And in most practices, the `private` ruleset is set to direct connection, which would cause these blocked sites to be proxied in the end, went direct and failed.

Thus, they shall be removed for a better user experience.