### PR TITLE
Update iyf

### DIFF
--- a/data/iyf
+++ b/data/iyf
@@ -1,6 +1,2 @@
 iyf.tv
 yfsp.tv
-
-# CDN used by iyf
-dnvodcdn.me
-pipecdn.vip


### PR DESCRIPTION
Updates `iyf` domain list: 
- `yfsp.tv` is the international site.
- `pipecdn.vip` is a newly discovered CDN.