### PR TITLE
Add more tapsi-related domains to category-travel-ir

### DIFF
--- a/data/category-travel-ir
+++ b/data/category-travel-ir
@@ -4,3 +4,6 @@ alibaba.ir
 flightio.com
 mrbilit.com
 tapsi.ir
+tapsi.cab
+tap33.me
+tap30.services


### PR DESCRIPTION
Apart from tapsi's main domain which is tapsi.ir, if you visit the PWA version of the app hosted on https://app.tapsi.cab, you could see that some of the resources are served from other domains. These must also be exempted from v2ray so that tapsi works fine while v2ray is connected.