### PR TITLE
Update cloudflare, cloudflare-cn, deepin, intel and intel-dev

### DIFF
--- a/data/cloudflare
+++ b/data/cloudflare
@@ -21,6 +21,7 @@ cloudflareok.com
 cloudflarepartners.com
 cloudflareportal.com
 cloudflarepreview.com
+cloudflareregistrar.com
 cloudflareresolve.com
 cloudflaressl.com
 cloudflarestatus.com

--- a/data/cloudflare-cn
+++ b/data/cloudflare-cn
@@ -1,3 +1,4 @@
+cf-china.info @cn
 cf-ns.com @cn
 cf-ns.net @cn
 cf-ns.site @cn

--- a/data/deepin
+++ b/data/deepin
@@ -1,8 +1,17 @@
 deepin.cn
 deepin.com
-deepin.io
-deepin.org
+deepin.io @!cn
+deepin.org @!cn
+deepin.org.cn
+sndu.cn
 
 # 统信
+51changxie.com
+51jianxie.cn
+91changxie.com
+changxie.com
 chinauos.com
+linglong.space
+linyaps.org.cn
+uniontech.cn
 uniontech.com

--- a/data/intel
+++ b/data/intel
@@ -25,6 +25,7 @@ intel.ch
 intel.cl
 intel.cm
 intel.cn @cn
+intel.co
 intel.co.ae
 intel.co.cr
 intel.co.id
@@ -38,7 +39,7 @@ intel.com.ar
 intel.com.au
 intel.com.bo
 intel.com.br
-intel.com.cn @cn
+intel.com.cn
 intel.com.co
 intel.com.ec
 intel.com.hk
@@ -57,6 +58,7 @@ intel.cr
 intel.cu
 intel.cz
 intel.de
+intel.dev
 intel.dk
 intel.dz
 intel.ec
@@ -69,6 +71,7 @@ intel.fr
 intel.ga
 intel.gd
 intel.ge
+intel.gg
 intel.gl
 intel.gm
 intel.gr
@@ -79,6 +82,7 @@ intel.hk
 intel.hn
 intel.ht
 intel.hu
+intel.id
 intel.ie
 intel.in
 intel.io
@@ -149,14 +153,9 @@ intel.vu
 intel.wf
 intel.yt
 
+altera.co.jp
 altera.com
 alteraforum.com
-alteraforums.com
-alteraforums.net
-alterauserforum.com
-alterauserforum.net
-alterauserforums.com
-alterauserforums.net
 buyaltera.com
 celeron.com
 celeron.net
@@ -167,17 +166,23 @@ cilk.com
 cilk.net
 cloudinsights.com
 clusterconnection.com
+comm-verse.com
 coreduo.com
 coreextreme.com
 crosswalk-project.com
 crosswalk-project.net
+dml-lang.org
 doceapower.com
 easic.com
 enpirion.com
 exascale-tech.com
 exploreintel.com
 gordonmoore.com
+granretomaintel.com
+granulate.io
+hackharassment.com
 insidefilms.com
+insight.tech
 intc.com
 intel-research.net
 intel-university-collaboration.net
@@ -199,11 +204,12 @@ intell.com
 intellearningseries.com
 intellinuxwireless.net
 intelnervana.com
-intelnet.Component
 intelplay.com
 intelquark.com
-intelrealsense.cn @cn
+intelrealsense.cn
 intelrealsense.com
+intelrealsense.net
+intelreimbursement.com
 intelrxt.com
 intelsalestraining.com
 intelsecurity.com
@@ -213,12 +219,15 @@ intelstore.com
 inteltechnologyprovider.com
 intelvmwarecybersecurity.com
 itnel.com
+killernetworking.com
 latencytop.com
 lookinside.com
 makebettercode.com
 makesenseofdata.com
+meccontroller.com
 movidius.com
 movidius.net
+movidius.org
 nervanasys.com
 nevex.com
 nextgenerationcenter.com
@@ -229,19 +238,35 @@ omnitek.tv
 openamt.com
 opendroneid.org
 optanedifference.com
+passwordday.org
 pc.com
 pentium.com
 pentium.net
 pintool.com
+pmem.org
+pmem.us
 poweredbyintel.com
+projectcircuitbreaker.com
 reconinstruments.com
 reconjet.com
 researchintel.com
 saffrontech.com
 sensorynetworks.com
+sigopt.com
+silicon-mobility.com
+siliconmobility.com
 siport.com
 smart-edge.com
+smart-edge.info
+smart-edge.io
+smart-edge.net
+smart-edge.org
+smart-edge.systems
+smartedge.info
+storageclassmemory.io
+storageclassmemory.org
 theintelstore.com
+threadingbuildingblocks.org
 thunderbolttechnology.net
 trustedanalytics.com
 trustedanalytics.net
@@ -251,6 +276,13 @@ vpro.net
 xeon.com
 xn--ztsq84g.cn # 奔腾.cn
 xscale.com
+yournewpclove.co.id
+yournewpclove.in.th
+yournewpclove.my
+yournewpclove.ph
+yournewpclove.sg
 
 # Barefoot Networks
 barefootnetworks.com
+
+full:prod.5.slot.cdn.salesforce-communities.com

--- a/data/intel-dev
+++ b/data/intel-dev
@@ -3,8 +3,14 @@ hyperscan.io
 intellinuxgraphics.com
 intellinuxgraphics.net
 oneapi.com
+oneapi.io
+opencas.io
+opendroneid.org
+openvino.ai
 openvinotoolkit.org
+renderingtoolkit.org
 snap-telemetry.io
+universalscalablefirmware.org
 
 # ACPI Component Architecture
 acpica.com


### PR DESCRIPTION
#### 科赋锐(北京) 信息科技有限公司 京ICP备2020045912号
`cf-china.info` 京ICP备2020045912号-28

#### 武汉深之度科技有限公司 鄂ICP备14003693号
`sndu.cn` 鄂ICP备14003693号-1

#### 统信软件技术有限公司 京ICP备20003780号
`uniontech.com` 京ICP备20003780号-2
`uniontech.cn` 京ICP备20003780号-3
`linglong.space` 京ICP备20003780号-4
`51jianxie.cn` 京ICP备20003780号-5
`91changxie.com` 京ICP备20003780号-6
`changxie.com` 京ICP备20003780号-7
`51changxie.com` 京ICP备20003780号-8
`deepin.org.cn` 京ICP备20003780号-10
`linyaps.org.cn` 京ICP备20003780号-12

---
`alteraforums.net`, `alterauserforum.net` and `alterauserforums.com` are expired and should be deleted.
`intel.com.cn` and `intelrealsense.cn` are not ICPed.

ref:
- https://crt.sh/?id=9990249479
- https://crt.sh/?id=19581031103