### PR TITLE
update apple-intelligence

### DIFF
--- a/data/apple-intelligence
+++ b/data/apple-intelligence
@@ -2,3 +2,4 @@
 full:apple-relay.mask.apple-dns.net
 full:apple-relay.apple.com
 full:apple-relay.cloudflare.com
+full:apple-relay.fastly-edge.com


### PR DESCRIPTION
该域名来自 https://support.apple.com/zh-cn/101555