### PR TITLE
Add category-automobile-cn with Chinese automotive domains

### DIFF
--- a/data/category-automobile-cn
+++ b/data/category-automobile-cn
@@ -1,0 +1,19 @@
+# 汽车
+
+# 汽车资讯
+autohome.com.cn # 汽车之家
+guazi.com # 瓜子二手车
+
+# 汽车品牌
+xiaopeng.com # 小鹏汽车
+nio.cn # 蔚来汽车
+lixiang.com # 理想汽车
+byd.com # 比亚迪
+geely.com # 吉利汽车
+gwm.com.cn # 长城汽车
+zeekrlife.com # 极氪汽车
+
+# 租车平台
+zuche.com # 神州租车
+1hai.cn # 一嗨租车
+wkzuche.com # 悟空租车

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -228,6 +228,8 @@ bosszhipin.com
 zhaopin.cn # 智联招聘
 moseeker.com # 仟寻招聘
 
+# 汽车
+include:category-automobile-cn
 
 # Social Media
 include:category-social-media-cn


### PR DESCRIPTION
Adds new category file for Chinese automobile industry including:
- Auto news sites (autohome.com.cn, guazi.com)
- Car brands (xiaopeng.com, nio.cn, lixiang.com, byd.com, etc.)
- Car rental platforms (zuche.com, 1hai.cn, wkzuche.com)

🤖 Generated with [Claude Code](https://claude.ai/code)