### PR TITLE
Update category-ai-!cn

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -1,4 +1,5 @@
 include:anthropic
+include:cerebras
 include:cursor
 include:google-deepmind
 include:groq

--- a/data/cerebras
+++ b/data/cerebras
@@ -1,0 +1,1 @@
+cerebras.ai


### PR DESCRIPTION
cloud.cerebras.ai has already banned the Hong Kong region. It is recommended to add it to the AI section.