### PR TITLE
Update geolocation-cn to re-include category-httpdns-cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -6,7 +6,7 @@ include:jiguang
 include:umeng
 
 # category-httpdns-cn is mainly for advertising purpose
-# include:category-httpdns-cn
+include:category-httpdns-cn
 
 # 号码认证
 # include:category-number-verification-cn


### PR DESCRIPTION
More Chinese apps use it to resolve domain names.

If it does not belong to .cn, it will cause these apps to resolve to non-Chinese IPs!

---

Regarding advertising issues:
@IceCodeNew [mentioned](https://github.com/v2fly/domain-list-community/pull/2324#discussion_r1745334568)
> Including them into geolocation-cn introduced a potential conflict to users' interests, as the policy bypassing domestic domains might be evaluated before rules that block advertising domains.

This is obviously incorrect, because geolocation-cn already contains many advertisements.
If users want to block ads, they will definitely put it above all rules.