### PR TITLE
Split bilibili-cdn from bilibili

### DIFF
--- a/data/bilibili
+++ b/data/bilibili
@@ -1,3 +1,4 @@
+include:bilibili-cdn
 include:bilibili-game
 
 
@@ -30,23 +31,8 @@ bilibili.net
 bilibili.tv @!cn
 bilibilipay.cn
 bilibilipay.com
-bilicdn1.com
-bilicdn2.com
-bilicdn3.com
-bilicdn4.com
-bilicdn5.com
 biligo.com
-biliimg.com
 biliintl.com @!cn
-bilivideo.cn
-bilivideo.com
-bilivideo.net
 dreamcast.hk @!cn
-hdslb.com
-hdslb.org
 im9.com
-maoercdn.com
-mincdn.com
 yo9.com
-
-full:upos-hz-mirrorakam.akamaized.net @!cn

--- a/data/bilibili-cdn
+++ b/data/bilibili-cdn
@@ -1,0 +1,16 @@
+bilicdn1.com
+bilicdn2.com
+bilicdn3.com
+bilicdn4.com
+bilicdn5.com
+biliimg.com
+bilivideo.cn
+bilivideo.com
+bilivideo.net
+hdslb.com
+hdslb.org
+
+maoercdn.com
+mincdn.com
+
+full:upos-hz-mirrorakam.akamaized.net @!cn


### PR DESCRIPTION
`bilibili-cdn` contains CDN domains that host images, videos, and static assets for bilibili that are irrelevent to business logic.

All domains are extracted from the existing `bilibili` category; no new domains have been added. `bilibili` now contains `bilibili-cdn` and should not be changed by this.

Usage: when you use proxies (just want) to bypass regional restrictions, you can securely route CDN domains to "direct outbound", thus saving proxy data traffic.