### PR TITLE
Add 2ch.org and 2ch.su to 2ch

### DIFF
--- a/data/2ch
+++ b/data/2ch
@@ -1,3 +1,4 @@
 2ch.hk
+2ch.life
 2ch.org
 2ch.su


### PR DESCRIPTION
2ch.life is dead, 2ch.org and 2ch.su are the actual domains as for now, 2ch.hk redirects to 2ch.org