### PR TITLE
category-scholar-uk: clean up

### DIFF
--- a/data/category-scholar-!cn
+++ b/data/category-scholar-!cn
@@ -10,7 +10,6 @@ include:google-scholar
 include:ieee
 include:knovel
 include:mit
-include:oup
 include:proquest
 include:sci-hub
 include:sciencedirect

--- a/data/category-scholar-uk
+++ b/data/category-scholar-uk
@@ -2,6 +2,7 @@
 
 include:cambridge
 include:imperialcollege
+include:oup
 
 # https://iridis.uk/ac-uk-domain-registration/
 # https://community.jisc.ac.uk/library/janet-services-documentation/terms-and-conditions-acuk


### PR DESCRIPTION
`category-scholar-uk` was added in #2298, containing 5k+ domains, and all end with `ac.uk` suffix.

According to [ac.uk domain policy](https://community.jisc.ac.uk/library/janet-services-documentation/terms-and-conditions-acuk):

> The ac.uk domain is managed to add value to organisations in the United Kingdom whose core mission is tertiary education and/or public research

Using a single `ac.uk` instead of those detailed domains should be better for proxy usage.

@ysakura99 @rootmelo92118 