### PR TITLE
Add turbopages.org to the Yandex data file

### DIFF
--- a/data/yandex
+++ b/data/yandex
@@ -9,6 +9,7 @@ admetrica.ru
 dzen.ru
 naydex.net
 rostaxi.org
+turbopages.org
 webvisor.com
 webvisor.org
 ya.ru


### PR DESCRIPTION
Turbo pages is [Yandex's technology](https://yandex.com/dev/turbo/). It is usually used when translating websites in Yandex Translator.