### PR TITLE
Add imagedelivery.net to Cloudflare data

### DIFF
--- a/data/cloudflare
+++ b/data/cloudflare
@@ -30,6 +30,7 @@ cloudflarestream.com
 cloudflaretest.com
 cloudflarewarp.com
 every1dns.net
+imagedelivery.net
 isbgpsafeyet.com
 one.one.one
 pacloudflare.com


### PR DESCRIPTION
"imagedelivery.net" is a domain provided by Cloudflare for its Image Delivery service.