### PR TITLE
Add 'r2.dev' to Cloudflare data

### DIFF
--- a/data/cloudflare
+++ b/data/cloudflare
@@ -35,6 +35,7 @@ isbgpsafeyet.com
 one.one.one
 pacloudflare.com
 pages.dev
+r2.dev
 trycloudflare.com
 videodelivery.net
 warp.plus


### PR DESCRIPTION
Cloudflare-managed https://r2.dev subdomain for public buckets