### PR TITLE
aliyun: add new domain

### DIFF
--- a/data/aliyun
+++ b/data/aliyun
@@ -3,6 +3,7 @@ alicdn.com
 alicloudapi.com
 alidayu.com
 alidns.com
+aligfwaf.com
 alikunlun.com
 alikunlun.net
 aliyun-inc.com


### PR DESCRIPTION
`aligfwaf.com`应该是阿里云的WAF，部分网站会接入。如`zhihuishu.com`的CNAME为` ibvda451bysh0cpfm35veahjrwtdwdtz.aligfwaf.com `（[link](https://bgp.he.net/dns/zhihuishu.com)），而后者的IP段属于阿里云（[link](https://bgp.he.net/dns/ibvda451bysh0cpfm35veahjrwtdwdtz.aligfwaf.com)）。将之添加至`aliyun`应该是合理的。