### PR TITLE
qcloud: add new domain

### DIFF
--- a/data/qcloud
+++ b/data/qcloud
@@ -131,6 +131,7 @@ tcloudhw.com
 tcloudhw.net
 tcloudscdn.com
 tcloudscdn.net
+tdnsstic1.cn
 tdnsx1.com
 techo.chat
 tefscloud.com


### PR DESCRIPTION
使用大陆的DNS，`res.hc-cdn.com`的CNAME会解析到`tdnsstic1.cn`。经搜索发现，后者的备案主体为「深圳市腾讯计算机系统有限公司」，推测大概率与腾讯云相关。