### PR TITLE
feat(geolocation-cn): add new domain

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -68,6 +68,10 @@ mypaas.com.cn
 myypark.com
 ## FUNCDN
 funcdn.com
+## 北京知道创宇信息技术股份有限公司
+jiashule.com
+jiasule.com
+yunaq.com
 ## 即刻雾联（北京）
 ## https://github.com/v2fly/domain-list-community/pull/1352#issuecomment-1345476790
 jikeiot.cloud
@@ -80,10 +84,6 @@ kaipuyun.net
 knet.cn
 ## 江西节点技术服务有限公司
 pkoplink.com
-## 北京知道创宇信息技术股份有限公司
-jiasule.com
-jiashule.com
-yunaq.com
 
 # E-commerce
 include:58tongcheng


### PR DESCRIPTION
`jiashule.com`为该CDN的域名之一，且其备案号对应单位为「北京知道创宇信息技术股份有限公司」。顺带将该公司的相关域名整合了一下。

参见：<https://help.yunaq.com/faq/88/index.html>，其中直接提及了`jiashule.com`。