### PR TITLE
akamai: add new domain

### DIFF
--- a/data/akamai
+++ b/data/akamai
@@ -78,3 +78,4 @@ janrainservices.com @cn
 skycdn.com.cn @cn
 soasta-dswb.com
 srtcdn.net
+tl88.net @cn


### PR DESCRIPTION
包括`res.cdn.office.net`在内的域名的CNAME为`a726.dsccn.w.tl88.net`。根据[这篇论文](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7886322)所述：

> Akamai has 388 (out of 12,319) customers that exhibit this behavior. For example, www.apple.com is resolved to e6858.dscc.akamaiedge.net from the US, and to e6858.e19.s.tl88.net in China. We confirmed that all tl88.net servers are in fact hosted on Chinese IPs (from China Unicom and China Telecom).

其[官网](https://www.akamai.com/solutions/content-delivery-network/china-cdn)也称，自己提供中国大陆的CDN加速服务。

此外，经过自己的尝试，对于`a726.dsccn.w.tl88.net`，使用大陆DNS解析出来的IP地址均位于国内（IPv6如`240e:979:9506::da5b:e012`，IPv4如`115.152.254.16`）。而[bgp.he.net](https://bgp.he.net/dns/a726.dsccn.w.tl88.net)的结果则显示，域名对应的IP地址处于美国。说明确实会因用户所处位置的不同，而更换接入点。

另一方面，这种在国内和国外均有CDN的域名，是否需要独立出`akamai-cn`这样的分类，然后添加到`geolocation-cn`中？类似于`cloudflare-cn`。