### PR TITLE
geolocation-cn: add cc-pay.cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -40,6 +40,7 @@ include:everbright
 include:pingan
 include:taikang
 
+cc-pay.cn # 航财通·校园付
 hsqh.net # 徽商期货有限责任公司
 
 # CDN or SDWAN


### PR DESCRIPTION
`cc-pay.cn`是北京航空航天大学用来缴费的网站，备案号为「京ICP备19036550号」。与其放在「教育」类别，我感觉放在「金融」更合适。