### PR TITLE
github-ads: add new category

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -17,6 +17,7 @@ include:dmm-ads
 include:duolingo-ads
 include:emogi-ads
 include:flurry-ads
+include:github-ads
 include:google-ads
 include:growingio-ads
 include:hiido-ads

--- a/data/github
+++ b/data/github
@@ -1,3 +1,4 @@
+include:github-ads
 include:npmjs
 
 atom.io

--- a/data/github-ads
+++ b/data/github-ads
@@ -1,0 +1,2 @@
+collector.github.com @ads
+copilot-telemetry.githubusercontent.com @ads


### PR DESCRIPTION
参见：<https://docs.github.com/en/copilot/reference/copilot-allowlist-reference>

此外，这两个域名均被添加至「EasyPrivacy」列表中。虽然官方称`default.exp-tas.com`亦用作遥测，但「EasyPrivacy」暂时并未收录。为了稳妥起见，还是暂时不添加了。