### PR TITLE
geolocation-cn: add miit.gov.cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -204,11 +204,18 @@ jsehealth.com
 ## 仁科医疗科技有限公司服务域名，为北大口腔和一些其他国内医院小程序提供服务
 mingxuan.store
 
+# Party and government offices & Public units
+gov.cn
+## 中国气象局
+cma.cn
+## 中央气象台
+nmc.cn
+
 # Public transportation
 include:airchina # 中国国际航空
 include:hainanairlines # 海南航空
 
-caac.gov.cn # 中国民航局
+# 中国民航局 caac.gov.cn
 ceair.com # 中国东方航空
 chinaexpressair.com # 华夏航空
 csair.com # 中国南方航空
@@ -434,7 +441,6 @@ include:chinamobile
 include:chinatelecom
 include:chinatower
 include:chinaunicom
-miit.gov.cn
 
 # 在线工具
 include:ipip # IPIP ip地理位置数据库
@@ -481,13 +487,6 @@ include:sinopec
 # 应城门户网站
 chugou360.com
 ycrx360.com
-
-# 中国气象局政府门户网站
-cma.gov.cn
-# 中国气象局
-cma.cn
-# 中央气象台
-nmc.cn
 
 # The following domains are carried over from geosite:cn.
 # TODO: Decide how to deal with these domains


### PR DESCRIPTION
工信部的网站，放在`Telecommunication`下应该是合适的吧。

此外，是否考虑将`gov.cn`添加在`geolocation-cn`中？就像`category-education-cn`中存在`edu.cn`一样。虽然`tld-cn`中存在`.cn`，但感觉单凭顶级域名来区分，并非绝对准确。而`gov.cn`应该没有这个顾虑。在[Google搜索「gov.cn」](https://www.google.com/search?q=gov.cn)的前几个结果中，国内解析出的IP似乎都在中国，好像没有找到反例。