### PR TITLE
Fix #3055

### DIFF
--- a/data/picacg
+++ b/data/picacg
@@ -10,6 +10,8 @@ picacomic.xyz
 wikawika.xyz
 
 # Image Resource Domain like `img.diwodiwo.xyz` `s3.diwodiwo.xyz` `storage.diwodiwo.xyz` `storage-b.diwodiwo.xyz`
-regexp:^([a-z0-9-]+\.)*(?!ad-display\.|ad-channel\.)[a-z0-9-]+\.diwodiwo\.xyz$
+
 ad-channel.diwodiwo.xyz @ads
 ad-display.diwodiwo.xyz @ads
+diwodiwo.xyz
+


### PR DESCRIPTION
Accroding to README.md:

> Note: Adding new regexp and keyword rules is discouraged because it is easy to use them incorrectly, and proxy software cannot efficiently match these types of rules.
