### PR TITLE
umeng-ads: add more domains

### DIFF
--- a/data/umeng-ads
+++ b/data/umeng-ads
@@ -1,6 +1,24 @@
 aaid.umeng.com @ads
 alog.umeng.com @ads
 alog.umengcloud.com @ads
+alogs.umeng.com @ads
+alogus.umeng.com @ads
+ar.umeng.com @ads
+aspect-upush.umeng.com @ads
+audid.umeng.com @ads
+ccs.umeng.com @ads
+cnlogs.umeng.com @ads
+cnlogs.umengcloud.com @ads
+# https://github.com/TG-Twilight/AWAvenue-Ads-Rule/issues/185
+# errlog.umeng.com @ads
+# errnewlog.umeng.com @ads
+new-aaid.umeng.com @ads
+new-aaid.umeng.com.gds.alibabadns.com @ads
+oc.umeng.com @ads
+plbslog.umeng.com @ads
+resolve.umeng.com @ads
+ulogs.umeng.com @ads
+ulogs.umengcloud.com @ads
 utoken.umeng.com @ads
 
 # CNZZ


### PR DESCRIPTION
参见：
- <https://corescholar.libraries.wright.edu/cgi/viewcontent.cgi?article=3008&context=etd_all>
- <https://ora.ox.ac.uk/objects/uuid:b0bf8cf4-7f13-4f28-9150-3468de6ea78b/files/srr171z625>
- StevenBlack/hosts#2735
- <https://reports.exodus-privacy.eu.org/en/trackers/119/>

暂时注释了`errlog.umeng.com`和`errnewlog.umeng.com`，参见：
- TG-Twilight/AWAvenue-Ads-Rule#185