### PR TITLE
Chore: remove unused key-value attribute feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	router "github.com/v2fly/v2ray-core/v5/app/router/routercommon"
@@ -161,8 +160,7 @@ func parseAttribute(attr string) (*router.Domain_Attribute, error) {
 		return &attribute, fmt.Errorf("invalid attribute: %s", attr)
 	}
 
-	// Trim attribute prefix `@` character
-	attribute.Key = strings.ToLower(attr[1:])
+	attribute.Key = strings.ToLower(attr[1:]) // Trim attribute prefix `@` character
 	attribute.TypedValue = &router.Domain_Attribute_BoolValue{BoolValue: true}
 	return &attribute, nil
 }


### PR DESCRIPTION
I scanned all text sources using the regex `@[^=\s]+=` , and found zero occurrences

https://github.com/search?q=repo%3Av2fly%2Fdomain-list-community+%2F%40%5B%5E%3D%5Cs%5D%2B%3D%2F&type=code

What does this parser originally used for? And Do we actually need this branch?

Edit: So basically, it  just a question of mine, if we should not remove this `@k=v` branch, then just close the PR, thanks all