### PR TITLE
geolocation-cn: add pospal.cn

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -48,6 +48,8 @@ hsqh.net
 lu.com
 lufax.com
 lufaxcdn.com
+## 银豹收银系统
+pospal.cn
 
 # CDN or SDWAN
 include:aws-cn


### PR DESCRIPTION
备案号：闽ICP备10208378号-2

有些点餐小程序会使用该域名（[例](https://www.instagram.com/p/DDZEuRRp075/)）