### PR TITLE
Add `ir` category as an alias of `category-ir`

### DIFF
--- a/data/ir
+++ b/data/ir
@@ -1,0 +1,2 @@
+# Same as "category-ir"
+include:category-ir


### PR DESCRIPTION
Almost no one would guess that Iranian domains are in ‍‍‍‍`category-ir` unless they look at this repo!

Since Iranian IPs are in `geoip:ir`, Iranian domains must also be in `geosite:ir`
