### PR TITLE
Add avito.ru and static-files domain

### DIFF
--- a/data/avito
+++ b/data/avito
@@ -1,0 +1,2 @@
+avito.ru
+avito.st

--- a/data/category-ru
+++ b/data/category-ru
@@ -18,6 +18,7 @@ ru.net
 
 include:category-gov-ru
 
+include:avito
 include:mailru-group
 include:okko
 include:ozon


### PR DESCRIPTION
avito.ru - popular russian peer-to-peer marketplace
avito.st - static-files domain (blocked outside Russia)