### PR TITLE
Remove 'futu' from category-finance includes

### DIFF
--- a/data/category-finance
+++ b/data/category-finance
@@ -4,7 +4,6 @@ include:category-bank-jp
 include:category-bank-mm
 
 include:fibank
-include:futu
 include:hsbc
 include:ibkr
 include:ifast


### PR DESCRIPTION
category-finance is included in geolocation-!cn
futu is included in cn
futu cannot be included in both geolocation-!cn and cn
futu is a chinese website
so remove futu from category-finance make futu only in cn