### PR TITLE
category-dev: add godbolt.org

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -91,6 +91,7 @@ getcomposer.org
 getzola.org
 git-scm.com
 gnu.org
+godbolt.org
 
 # PuTTY and some software official websites.
 greenend.org.uk


### PR DESCRIPTION
用于查看代码编译结果的网站，放在`category-dev`应当比较合适。

<img width="1920" height="951" alt="图片" src="https://github.com/user-attachments/assets/ed7cb884-cbcd-47ce-a665-be07c8430f65" />

解析结果似乎都不在中国大陆。

<img width="1920" height="951" alt="图片" src="https://github.com/user-attachments/assets/af49135f-ceb8-4537-bf22-19b0f01fad49" />
