### PR TITLE
geolocation-!cn: add dmhy.org

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -291,6 +291,7 @@ include:demonoid
 include:nyaa
 include:piratebay
 include:rarbg
+dmhy.org
 
 # User scripts
 greasyfork.org


### PR DESCRIPTION
虽然`dmhy.org`也存在于`category-pt`中，但是其本身也是BT站点，我认为在`Torrent websites`分类下添加该域名是合适的。

此外，`category-pt`似乎未被任何其他列表包含。或许可以拆分成`-cn`和`-!cn`？