### PR TITLE
connectivity-check: add redirect.archlinux.org

### DIFF
--- a/data/connectivity-check
+++ b/data/connectivity-check
@@ -1,8 +1,9 @@
 # Apple
 captive.apple.com
 
-# ArchLinux
-ping.archlinux.org
+# Arch Linux
+full:ping.archlinux.org
+full:redirect.archlinux.org # Canonical Name of ping.archlinux.org
 
 # Cloudflare
 cp.cloudflare.com


### PR DESCRIPTION
虽然Arch Linux的NetworkManager确实是向`ping.archlinux.org`发起请求以测试，但是`ping.archlinux.org`的CNAME记录指向`redirect.archlinux.org`（[1](https://bgp.he.net/dns/ping.archlinux.org)）。至少在sing-box的DNS和路由规则中，需要同时处理`ping.archlinux.org`和`redirect.archlinux.org`两个域名，仅处理`ping.archlinux.org`似乎无效。所以从实用角度而言，我认为应该额外添加`redirect.archlinux.org`。