### PR TITLE
Refactor main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,14 +123,6 @@ func exportPlainTextList(list []string, refName string, pl *ParsedList) {
 	}
 }
 
-func removeComment(line string) string {
-	idx := strings.Index(line, "#")
-	if idx == -1 {
-		return line
-	}
-	return strings.TrimSpace(line[:idx])
-}
-
 func parseDomain(domain string, entry *Entry) error {
 	kv := strings.Split(domain, ":")
 	if len(kv) == 1 {
@@ -166,7 +158,6 @@ func parseAttribute(attr string) (*router.Domain_Attribute, error) {
 }
 
 func parseEntry(line string) (Entry, error) {
-	line = strings.TrimSpace(line)
 	parts := strings.Split(line, " ")
 
 	var entry Entry
@@ -201,9 +192,13 @@ func Load(path string) (*List, error) {
 	}
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		line = removeComment(line)
-		if len(line) == 0 {
+		line := scanner.Text()
+		// Remove comments
+		if idx := strings.Index(line, "#"); idx != -1 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
 		entry, err := parseEntry(line)


### PR DESCRIPTION
1. 完善对选择性包含的支持
  
落实我在[这里](https://github.com/v2fly/domain-list-community/issues/390#issuecomment-3649035102)的想法，`include:filename @attr1 @attr2 @-attr3 @-attr4` 代表包含 filename 中同时满足带有 `@attr1`，带有 `@attr2`，不带 `@attr3`，不带 `@attr4` 这样的规则

更为实际的作用有：在 `geolocation-cn` 里写 `include:bytedance @-!cn` 就不会向 `geolocation-cn` 引入 `tiktok` 这类带有 `@!cn` 属性的域名；可以直接在 `category-ads` 中使用 `include:xxx @ads`，然后将当前 data 目录下的 `xxx-ads` 文件合并到 `xxx`，从而减少文件数量

2. 新增 affiliation/附属 语法

格式与 attribute 类似，使用 `&` 符号，与 attribute 不冲突，可以有多个。规则会被额外添加到 affiliation 对应的列表中

例如在 `data/google` 中写 `youtube.com &youtube &category-entertainment`，`[domain:]youtube.com` 会被加到 `geosite:google`, `geosite:youtube`, `geosite:category-entertainment` 三项中去

这样可以在不影响最终 `dlc.dat` 文件的情况下，减少 data 中的文件数量，也可以避免同一条规则需要在多个文件中多次使用不便管理（子应用可以合并到母公司对应文件，如 youtube 合并到 google；规则数量少的文件可以合并到上级 category）。即使 data 目录不存在单独的文件 `data/affiliation`，也不影响 `geosite:affiliation` 的使用

3. 支持对规则的去重

简单去重：完全相同的规则仅保留一条，支持所有类型的规则

高级去重：去除不带属性的 full/domain 类型的多余的子域名规则，如同一列表中存在 `domain:example.org` 时，不会再包含 `a.b.c.example.org`

仅支持 full/domain 类型的规则；为保证 `@ads` 机制正常运作，不会去除带有属性的域名；为提高程序运行效率（保证兼容性？）不会去除仅两级的域名。即使列表中包含 `domain:cn`，仍会保留 `domain:example.cn`。这个如果不需要可以改掉

完善去重以后可以减少生成二进制文件的体积，可以提高程序运行效率（~~尽管作用很小~~）；可以增加类似 #3097 那样的精细而又冗余的条目

4. 其他改进

主要是增加了对 type/value/attributes/affiliations 的格式检查（对 regex 的检查是前段时间已经加了的），其他的参考提交信息

这些修改是在 Gemini 指导下，一行一行人工写的，也经过了我自己的多次测试。不过我的 golang 水平有限，现学现卖可能有问题