### PR TITLE
private: add gw.buaa.edu.cn

### DIFF
--- a/data/private
+++ b/data/private
@@ -183,3 +183,7 @@ zte.home
 # Tailscale Magic DNS
 # Reference: https://tailscale.com/kb/1081/magicdns/#fully-qualified-domain-names-vs-machine-names
 ts.net
+
+# Beihang University Gateway
+# Reference: https://nic.e1.buaa.edu.cn/__local/4/E3/F7/5E7BBA6B4CABA82D0400481F1F3_F2819AC2_24439.pdf
+full:gw.buaa.edu.cn


### PR DESCRIPTION
`private`分类会接收学校、企业内网的域名吗？`gw.buaa.edu.cn`是北京航空航天大学的内网网关地址，用以校园网验证。公网解析不出地址。

参见：
- AdguardTeam/AdguardForAndroid#5722
- AdguardTeam/HttpsExclusions#656