### PR TITLE
feat(jiguang): add missing domain easytomessage.com

### DIFF
--- a/data/jiguang
+++ b/data/jiguang
@@ -3,6 +3,7 @@
 5566ua.com
 aurorapush.cn
 e0n.cn
+easytomessage.com
 japps.cn
 jchat.io
 jiguang.cn


### PR DESCRIPTION
Add missing domain for Jiguang (JPush) service.

According to the official Jiguang documentation, `easytomessage.com` is a required domain for the push service to function correctly on network-restricted environments.

Reference:
https://community.jiguang.cn/article/408970