### PR TITLE
xiaomi-ads: add stats.music.xiaomi.com

### DIFF
--- a/data/xiaomi-ads
+++ b/data/xiaomi-ads
@@ -14,6 +14,7 @@ logupdate.avlyun.sec.miui.com @ads
 misc.in.duokanbox.com @ads
 sentry.d.mi.com @ads
 sentry.d.xiaomi.net @ads
+stats.music.xiaomi.com @ads
 tjqonline.cn @ads
 tracker.ai.xiaomi.com @ads
 tracking.miui.com @ads


### PR DESCRIPTION
小米自带的音乐软件会连接到此域名。经个人测试，似乎并没有负面影响。

此外，该域名也被包含在其他广告屏蔽列表中（[1](https://github.com/MahanRahmati/MiuiHost/blob/main/miui_host)、[2](https://github.com/What-Zit-Tooya/Ad-Block/blob/main/Main-Blocklist/Ad-Block-HOSTS.txt)）。