### PR TITLE
xiaomi-ads: add tracker.xiaomixiaoai.com

### DIFF
--- a/data/xiaomi-ads
+++ b/data/xiaomi-ads
@@ -17,4 +17,5 @@ sentry.d.xiaomi.net @ads
 stats.music.xiaomi.com @ads
 tjqonline.cn @ads
 tracker.ai.xiaomi.com @ads
+tracker.xiaomixiaoai.com @ads
 tracking.miui.com @ads


### PR DESCRIPTION
小米手机的小爱同学会连接到此域名。经个人测试，拦截后似乎并没有负面影响。

参见：
- privacy-protection-tools/anti-AD#1095

<details>
<summary>图片</summary>

![Screenshot_2026-01-10-14-29-40-563_io nekohasekai sfa](https://github.com/user-attachments/assets/de33a04e-d5bb-4c34-bd7e-4ff4adc21386)

</details>
