### PR TITLE
geolocation-cn: add more domains

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -196,3 +196,7 @@ reyun.com
 zhugeapi.com
 zhugeapi.net
 zhugeio.com
+
+# 车来了
+atrace.chelaile.net.cn
+logs.chelaile.net.cn

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -230,8 +230,12 @@ xiamenair.com # 厦门航空
 12306.cn
 95306.cn
 ccrgt.com
+## 车来了
+chelaile.net.cn
 ## 跨境巴士
 kuajing84.com
+## 掌上公交
+mygolbs.com
 ## 宁停车
 ningtingche.com
 ## 航旅纵横


### PR DESCRIPTION
「车来了」和「掌上公交」都是公交实时查询平台，放在`Public transportation`分类下应该没有问题。它们的下载量在应用商店中显示上亿，应该值得加入该列表中。

关于「车来了」的广告域名，参见：
- <https://github.com/GoodHolidays/ConnersHua/blob/master/Quantumult/X/Filter/Advertising.list>
- <https://mdr.skyeye.qianxin.com/forum/share/650>，其提到了在`atrace.chelaile.net.cn`中发现了广告点。