### PR TITLE
category-games: add more domains

### DIFF
--- a/data/4399
+++ b/data/4399
@@ -17,6 +17,7 @@
 4399biule.com
 4399dmw.com
 4399er.com
+4399hdhh.com
 4399hhh.com
 4399inc.com
 4399mail.com
@@ -30,17 +31,22 @@
 4399yyy.com
 5054399.com
 5054399.net
+5wyxi.com
 71acg.com
 71acg.net
+abdf002.com
 appeeres.com
+buke999.com
 bx1k.com
 edu4399.com
 funnycore.com
 guoping123.com
+haohaowan.net
 i3839.com
 ihykb.com
 img4399.com
 mail4399.com
+maindown4399.com
 me4399.com
 my4399.com
 mysiteres.com
@@ -52,4 +58,6 @@ wanwan4399.com
 we4399.com
 webgame163.com
 youba.com
+yxhapi.com
 yxhhdl.com
+yxhimg.com

--- a/data/category-games-!cn
+++ b/data/category-games-!cn
@@ -38,6 +38,7 @@ include:wbgames
 include:xbox
 include:ynoproject
 
+dinopoloclub.com
 dodi-repacks.download
 dodi-repacks.site
 fabricmc.net
@@ -48,8 +49,10 @@ humblebundle.com
 joinsquad.com
 loverslab.com
 minecraft.wiki
+mobimon.com.tw
 nexus-cdn.com
 nexusmods.com
+noxygames.com
 offworldindustries.com
 offworldindustries.net
 papermc.io
@@ -57,5 +60,7 @@ planetminecraft.com
 prismlauncher.org
 protondb.com
 quiltmc.org
+rayark.download
+rayark.net
 speedrun.com
 steamdb.info

--- a/data/category-games-cn
+++ b/data/category-games-cn
@@ -26,14 +26,16 @@ fxt365.com
 gameabc.com
 # 游戏魅 合肥启云软件 皖B2-20160087-3
 gamemei.com
+# Enhance Gaming
+heavenlywind.cc
 # 乐都网 浙ICP备2024091002号-2
 ledu.com
 # 龙图游戏 京ICP备11023195号
 longtugame.com
 # 北京慕飞科技 京ICP备20006112号-2
 morefreegame.com
-# Enhance Gaming
-heavenlywind.cc
+# Phira
+phira.cn
 # 沪ICP备18041304号-1
 tgpro.top
 tgprocs.net


### PR DESCRIPTION
添加到4399的这些域名，ICP备案主体都是「厦门游乐互动科技有限公司」。根据[企查查](https://top.qcc.com/tc/9244ce55ff53.html)以及[h.api.4399.com](https://h.api.4399.com/)，看起来是4399旗下的企业