### PR TITLE
kinopub: add cdn-service.space

### DIFF
--- a/data/kinopub
+++ b/data/kinopub
@@ -1,6 +1,6 @@
+cdn-service.space
 kino.pub
 kinopub.online
-cdn-service.space # API for app version check
 
 # Mirror sites
 gfw.ovh # sub domains mirror


### PR DESCRIPTION
## Summary

Add `cdn-service.space` to the kinopub domain list.

## Details

This domain is used by the Kinopub Android TV app for version checking / API calls. Without routing this domain through VPN, the app hangs on startup in regions where this domain is blocked (e.g., Russia).

**Discovery:** Network traffic analysis on 2026-01-27 revealed that the Kinopub app on Android TV was failing to start because `cdn-service.space` was being blocked when accessed directly.

## Testing

After adding this domain to routing rules, the Kinopub app successfully loads and displays content.