### PR TITLE
add crixet.com to openai

### DIFF
--- a/data/openai
+++ b/data/openai
@@ -1,11 +1,11 @@
 # Main domain
-chatgpt.com
 chat.com
+chatgpt.com
+crixet.com
 oaistatic.com
 oaiusercontent.com
 openai.com
 sora.com
-crixet.com
 
 # CDN & API
 openai.com.cdn.cloudflare.net


### PR DESCRIPTION
Crixet has been acquired by OpenAI, per https://crixet.com