### PR TITLE
kinopub: add cdn2cdn.com, cdn2site.com, pushbr.com

### DIFF
--- a/data/kinopub
+++ b/data/kinopub
@@ -1,4 +1,3 @@
-cdn-service.space
 kino.pub
 kinopub.online
 
@@ -7,7 +6,9 @@ gfw.ovh # sub domains mirror
 mos-gorsud.co # kinopub domain to generate a mirror site through gfw.ovh
 
 # kinopub CDN servers
-regexp:(\w+)-static-[0-9]+\.cdntogo\.net$
+cdn-service.space
 cdn2cdn.com
 cdn2site.com
 pushbr.com # poster images CDN
+
+regexp:(\w+)-static-[0-9]+\.cdntogo\.net$


### PR DESCRIPTION
## Summary

Add additional CDN domains used by Kinopub streaming service:

- `cdn2cdn.com` - video streaming CDN
- `cdn2site.com` - video streaming CDN  
- `pushbr.com` - poster/thumbnail images CDN

## Discovery

These domains were discovered via network traffic analysis on the Kinopub web app (kino.pub). Without proxying these domains:
- Video streaming may fail on some CDN nodes
- **Poster images fail to load entirely** (pushbr.com hosts all movie/series thumbnails)

## Evidence

From Chrome DevTools Sources panel on kino.pub:
- `m.pushbr.com/poster/item/small/*` - thumbnail images
- `cdn2cdn.com` and `cdn2site.com` appear in video player network requests

These domains are blocked in Russia, causing Kinopub to be partially unusable without proper proxy configuration.