### PR TITLE
Add geosite:radiko

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -54,6 +54,7 @@ include:pixiv
 include:plutotv
 include:pocketcasts
 include:primevideo
+include:radiko
 include:roku
 include:showtimeanytime
 include:sling

--- a/data/radiko
+++ b/data/radiko
@@ -1,5 +1,5 @@
 # radiko official access and streaming domains
 
+radiko-cf.com
 radiko.jp
 smartstream.ne.jp
-radiko-cf.com


### PR DESCRIPTION
Add a new geosite category for radiko, a Japanese internet radio service.

This includes official website access and streaming-related domains used by radiko.jp.