### PR TITLE
geolocation-!cn: include more sub lists

### DIFF
--- a/data/category-non-domestic-cn
+++ b/data/category-non-domestic-cn
@@ -1,0 +1,31 @@
+# Part of Chinese entities but exclusively serving for non-cn area
+
+include:alibaba @!cn
+include:anker @!cn
+include:bilibili @!cn
+include:boc @!cn
+include:bytedance @!cn
+include:ccb @!cn
+include:chinamobile @!cn
+include:chinatelecom @!cn
+include:chinaunicom @!cn
+include:citic @!cn
+include:cmb @!cn
+include:ctrip @!cn
+include:deepin @!cn
+include:dewu @!cn
+include:didi @!cn
+include:eastmoney @!cn
+include:huawei @!cn
+include:icbc @!cn
+include:ipip @!cn
+include:iqiyi @!cn
+include:jd @!cn
+include:oppo @!cn
+include:pingan @!cn
+include:sina @!cn
+include:tencent @!cn
+include:vivo @!cn
+include:xd @!cn
+include:xiaohongshu @!cn
+include:xiaomi @!cn

--- a/data/cn
+++ b/data/cn
@@ -2,3 +2,4 @@
 
 include:tld-cn
 include:geolocation-cn
+#include:category-non-domestic-cn

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -1,5 +1,8 @@
 # This list contains domains that don't have access point in China mainland. This is opposite to geolocation-cn.
 
+# Part of Chinese entities but exclusively serving for non-cn area
+include:category-non-domestic-cn
+
 # AI Chat
 include:category-ai-!cn
 


### PR DESCRIPTION
They are part of Chinese entities but **exclusively** serving for non-cn area

As https://github.com/v2fly/domain-list-community/pull/3198 moved them out from `category-xxx-cn`/`geolocation-cn`, this adds them into `category-xxx-!cn`/`geolocation-!cn`

If there's no objection, I'll merge this in a week