### PR TITLE
Google Gemini adjustments

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -10,9 +10,7 @@ robinfrontend-pa.googleapis.com
 
 # Google AI Studio
 full:ai.google.dev
-full:alkalicore-pa.clients6.google.com
-full:alkalimakersuite-pa.clients6.google.com
-full:webchannel-alkalimakersuite-pa.clients6.google.com
+clients6.google.com
 generativeai.google
 makersuite.google.com
 


### PR DESCRIPTION
Google Gemini use a lot of new *.clients6.google.com domains
