### PR TITLE
category-ru: add t1.cloud and yclients.com; kinopub: new cdn

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -54,4 +54,6 @@ ngenix.net     # NGENIX is a Russian provider of acceleration and security servi
 pochta.ru      # Russian post
 qms.ru         # Russian internet speed testing service
 rustore.ru     # RuStore is a Russian mobile app store for Android
+t1.cloud       # Russian cloud storage provider
 taxsee.com     # Taxi for business (self-employed drivers)
+yclients.com   # Russian SaaS platform for online booking and business automation for service companies

--- a/data/kinopub
+++ b/data/kinopub
@@ -11,5 +11,6 @@ cdn-service.space
 cdn2cdn.com
 cdn2site.com
 pushbr.com # poster images CDN
+smarttvcdn.online
 
 regexp:(\w+)-static-[0-9]+\.cdntogo\.net$


### PR DESCRIPTION
Added new service domains:

- yclients.com - Russian SaaS platform for online booking and business automation for service companies
- t1.cloud - Russian cloud storage provider
- Added a new CDN entry related to Kinopub streaming infrastructure.

The attached Kinopub CSV contains fresh parsing data extracted from the latest version of the application.
[knpbapk134.csv](https://github.com/user-attachments/files/25467232/knpbapk134.csv)
