### PR TITLE
apple: mark more sub domains with cn attr

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -752,10 +752,10 @@ courier-push-apple.com.akadns.net
 full:amp-api-edge-lb-cn.itunes-apple.com.akadns.net @cn
 full:amp-api-edge-lb.itunes-apple.com.akadns.net @cn
 full:amp-api-edge.apps.apple.com @cn
+full:amp-api-edge.music.apple.com @cn
 full:amp-api-search-edge.apps.apple.com @cn
 full:amp-api.apps.apple.com @cn
 full:amp-api.music.apple.com @cn
-full:amp-api-edge.music.apple.com @cn
 full:aod-ssl.itunes.apple.com @cn
 full:aod.itunes.apple.com @cn
 full:api-edge.apps.apple.com @cn


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

When I accessed music.apple.com with rule geosite:apple@cn>outboundTag:direct already set in my route settings, I found that there were still some domains went through proxy. Here are the ping results made in itdog.cn
<img width="1300" height="7779" alt="amp-api-edge music apple com_多地Ping值测试" src="https://github.com/user-attachments/assets/df3408ca-931a-4f08-a808-ae6a6ab5984f" />
<img width="1300" height="7779" alt="musicstatus music apple com_多地Ping值测试" src="https://github.com/user-attachments/assets/dfa1e9e3-539b-41e7-bd3c-16ddf9a39aab" />
<img width="1300" height="7779" alt="mvod itunes apple com_多地Ping值测试" src="https://github.com/user-attachments/assets/2b6aea68-b173-4370-a96c-64be9b141508" />
<img width="1300" height="7779" alt="speedysub music apple com_多地Ping值测试" src="https://github.com/user-attachments/assets/e966d91e-1514-4628-874b-285c364746fa" />
