### PR TITLE
Add plex domain list for routing

### DIFF
--- a/data/category-companies
+++ b/data/category-companies
@@ -66,6 +66,7 @@ include:openweather
 include:oracle
 include:panasonic
 include:pccw
+include:plex
 include:qnap
 include:qualcomm
 include:qwant

--- a/data/plex
+++ b/data/plex
@@ -1,0 +1,14 @@
+# Plex Media Server domains
+# Basic domains for Plex services
+plex.com
+plex.services
+plex.tv
+plexapp.com
+
+# Note for Plex users
+# * Plex's mechanism requires certain domains to go through a direct connection.
+# * Using a proxy for these domains may cause the system to malfunction.
+# * If you wish to access plex domains through a proxy, remember to ensure the following domains remain directly connected.
+# * Related domains:
+# plex.direct
+# v4.plex.tv


### PR DESCRIPTION
Add data/plex with Plex domains. Parent domains cover all subdomains per project guidelines. v4.plex.tv and domain:plex.direct are marked with @direct attribute as they are required for Plex to work properly.

Plex is a popular media server service and deserves its own geosite category. 

Usage:
- geosite:plex - matches all Plex domains
- geosite:plex@direct - matches only direct connection domains

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

