### PR TITLE
category-entertainment-cn: add 172mix.com

### DIFF
--- a/data/category-entertainment-cn
+++ b/data/category-entertainment-cn
@@ -44,6 +44,8 @@ ldmnq.com
 lsplayer.com
 yeshen.com
 
+# 172Mix 舞曲音乐
+172mix.com
 # 17K小说
 17k.com
 # https://github.com/supzhang/epg


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Fix https://github.com/MetaCubeX/meta-rules-dat/issues/136