### PR TITLE
jetbrains: add jetbrains.cloud

### DIFF
--- a/data/jetbrains
+++ b/data/jetbrains
@@ -1,14 +1,15 @@
+datalore.io
 intellij.com
 intellij.net
 intellij.org
+jb.gg
+jetbrains.cloud
 jetbrains.com
 jetbrains.net
 jetbrains.space
 jetbrains.team
-jetbrains.cloud
-datalore.io
 kotlinlang.org
+youtrack.cloud
+
 cdn.jetbrains.com @cn
 download-cdn.jetbrains.com.cn @cn
-jb.gg
-youtrack.cloud


### PR DESCRIPTION
Just plus one domain for JetBrains.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

