### PR TITLE
mozilla: remove two redundant subdomains and rust

### DIFF
--- a/data/mozilla
+++ b/data/mozilla
@@ -1,6 +1,5 @@
 include:firefox
 include:mdn
-include:rust
 
 mozgcp.net
 mozilla.com
@@ -24,7 +23,10 @@ seamonkey-project.org
 thunderbird.net
 
 # Mozilla Location Service
-location.services.mozilla.com
+# * Overrided by above `mozilla.com`
+# * In March 2024, Mozilla announced the project was being discontinued
+#location.services.mozilla.com
 
 # Mozilla Push Service
-push.services.mozilla.com
+# * Overrided by above `mozilla.com`
+#push.services.mozilla.com


### PR DESCRIPTION
Rust now belongs to Rust Foundation, not mozilla

`*.services.mozilla.com` is overrided by `mozilla.com`, so comment them out. Link to #2334

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

