### PR TITLE
category-ai-!cn: add lovart.ai

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -38,6 +38,7 @@ dify.ai
 duck.ai
 gateway.ai.cloudflare.com
 kiro.dev
+lovart.ai
 meta.ai
 mistral.ai
 openart.ai


### PR DESCRIPTION
Hi, lovart.ai is an image and video design AI application, and we really need it to be added to Geosite.

