### PR TITLE
geolocation-!cn: add app-pay.jp

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -45,6 +45,8 @@ include:paypal
 include:softbank
 include:stripe
 include:visa
+## アプリペイ
+app-pay.jp
 
 # CDN companies & Services
 include:category-cdn-!cn


### PR DESCRIPTION
Add `app-pay.jp` to `geolocation-!cn`
>AppPay enables web-based payments
outside the app environment.
App publishers and developers can easily create
out-of-app payment systems,
reducing app store fees from 30% to 5%.
AppPay is provided by [Digital Garage, Inc.](https://www.garage.co.jp/en/),
listed on the Tokyo Stock Exchange Prime Market.