### PR TITLE
samsung: add iot domains

### DIFF
--- a/data/samsung
+++ b/data/samsung
@@ -19,7 +19,9 @@ samsungeshop.com.cn @cn
 samsunggalaxyfriends.com
 samsunghealth.com
 samsungiotcloud.com
+samsungiots.com
 samsungknox.com
 samsungosp.com
 samsungqbe.com
 samsungrs.com
+smartthings.com


### PR DESCRIPTION
Added domains required for downloading SmartThings add-ons for wearable devices. For example, Samsung SmartTag 2.
The domains were determined experimentally when attempting to add a tag to a phone.

