### PR TITLE
remove knovel

### DIFF
--- a/data/category-scholar-!cn
+++ b/data/category-scholar-!cn
@@ -8,7 +8,6 @@ include:doi
 include:elsevier
 include:google-scholar
 include:ieee
-include:knovel
 include:mit
 include:proquest
 include:sci-hub

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -85,7 +85,6 @@ include:embl
 include:freecodecamp
 include:kaggle
 include:khanacademy
-include:knovel
 include:laracasts
 include:libgen
 include:lifewire

--- a/data/knovel
+++ b/data/knovel
@@ -1,1 +1,0 @@
-knovel.com


### PR DESCRIPTION
Elsevier acquired Knovel in 2013

`data/knovel` has only one domain: `knovel.com`, and it's already in `data/elsevier`

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

