### PR TITLE
kinopub: add ahc.ovh

### DIFF
--- a/data/kinopub
+++ b/data/kinopub
@@ -3,6 +3,7 @@ kinopub.online
 kpdl.link
 
 # Mirror sites
+ahc.ovh # sub domains mirror
 gfw.ovh # sub domains mirror
 mos-gorsud.co # kinopub domain to generate a mirror site through gfw.ovh
 


### PR DESCRIPTION
My mirror is a subdomain of ahc.ovh

<img width="591" height="421" alt="image" src="https://github.com/user-attachments/assets/5356c9d0-47c2-48bb-89eb-387959fdd49b" />


<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

