### PR TITLE
category-entertainment-ru: add beeline.tv

### DIFF
--- a/data/category-entertainment-ru
+++ b/data/category-entertainment-ru
@@ -11,6 +11,7 @@ include:okko
 include:wink
 24h.tv
 amediateka.ru
+beeline.tv
 ivi.ru
 premier.one
 smotreshka.tv


### PR DESCRIPTION
## Summary
- Add `beeline.tv` to `category-entertainment-ru` list
- Beeline TV is a Russian streaming service by VEON (Beeline) — movies, TV series, live TV channels

## Details
- **Main domain:** `beeline.tv`
- **Subdomains** (covered automatically by domain match): `web-prod.beeline.tv`, `rest.beeline.tv`, `images.beeline.tv`, `static.beeline.tv`, `video.beeline.tv`
- **External dependencies:** `mediavitrina.ru` (media player), `vimpelcom.ru` (logging) — already in `category-ru`
- Service is available only inside Russia, should be routed directly for users behind proxy