### PR TITLE
category-electronic-cn: remove non-cn domains

### DIFF
--- a/data/category-electronic-cn
+++ b/data/category-electronic-cn
@@ -17,11 +17,10 @@ bouffalolab.com
 cxmt.com
 
 # 乐鑫信息科技
+#include:espressif
 esp8266.cn
-esp8266.com
 esp8266.com.cn
 espressif.cn
-espressif.com
 espressif.com.cn
 
 # 华秋电子


### PR DESCRIPTION
They were added in `espressif` and included in `geolocation-!cn`.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

