### PR TITLE
category-acg: add bestdori.com

### DIFF
--- a/data/category-acg
+++ b/data/category-acg
@@ -1,4 +1,5 @@
 # Game
+bestdori.com
 colorfulstage.com
 
 # Idol


### PR DESCRIPTION
《BanG Dream! 少女乐团派对！》的第三方数据站。不太确定放在`category-acg`还是`category-games-!cn`更合适，姑且和比较接近的`colorfulstage.com`放在一起了