### PR TITLE
category-entertainment: add openrec

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -49,6 +49,7 @@ include:netflix
 include:niconico
 include:now
 include:olevod
+include:openrec
 include:pbs
 include:pixiv
 include:plutotv

--- a/data/openrec
+++ b/data/openrec
@@ -1,0 +1,2 @@
+full:dqd0jw5gvbchn.cloudfront.net
+openrec.tv


### PR DESCRIPTION
OPENREC.tv is a Japanese live-streaming platform primarily focused on video games and eSports.