### PR TITLE
DOH dictionary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,13 @@ jobs:
         run: |
           echo "RELEASE_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "TAG_NAME=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
+          echo "DOH_EXTRA=https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/master/doh-domains.txt" >> $GITHUB_ENV
         shell: bash
+
+      - name: Import data from external sources
+        run: |
+          cd code || exit 1
+          curl -fsSL $DOH_EXTRA | awk 'NR == 1 { print "" } NF > 0 { print "full:"$0 }' >> ./data/category-doh
 
       - name: Build dlc.dat and plain lists
         run: |


### PR DESCRIPTION
Hi! The original category-doh doesn't include many necessary browser-specific domains, such as:

 - chrome.cloudflare-dns.com
 - chromium.dns.nextdns.io
 - firefox.dns.nextdns.io
 - mozilla.cloudflare-dns.com
 - opera.cloudflare-dns.com

And more more others:

 - 1dot1dot1dot1.cloudflare-dns.com
 - chrome.cloudflare-dns.com
 - cloudflare-dns.com
 - dns.cloudflare.com
 - dns64.cloudflare-dns.com
 - dooh.cloudflare-dns.com
 - family.cloudflare-dns.com
 - mozilla.cloudflare-dns.com
 - odoh.cloudflare-dns.com
 - opera.cloudflare-dns.com
 - security.cloudflare-dns.com
 - tor.cloudflare-dns.com

- dns.opendns.com
- doh.familyshield.opendns.com
- doh.opendns.com
- doh.sandbox.opendns.com
- familyshield.opendns.com
- resolver1-fs.opendns.com
- resolver1.ipv6-sandbox.opendns.com
- resolver1.opendns.com
- resolver2-fs.opendns.com
- resolver2.ipv6-sandbox.opendns.com
- resolver2.opendns.com
- sandbox.opendns.com

I suggest expanding the category with an automatically updated list. Maybe there's a better way to do this. Thanks!


