### PR TITLE
sber: added Jivo domains

### DIFF
--- a/data/sber
+++ b/data/sber
@@ -45,6 +45,23 @@ zvuk.com
 sber.pro
 full:sberpro.vedomosti.ru
 
+# Jivo/Jivochat/Jivosite
+jivo.chat
+jivo.ru
+jivochat.com
+jivochat.co.in
+jivochat.co.za
+jivochat.com.br
+jivochat.com.co
+jivochat.com.pe
+jivochat.com.tr
+jivochat.de
+jivochat.es
+jivochat.ng
+jivochat.ru
+jivosite.com
+jivosite.ru
+
 # Ads/tracking
 sbermarketing.ru @ads
 full:clickstream.sberbank.ru @ads


### PR DESCRIPTION
Added Jivo domains. Jivo is a "developer an omnichannel application for customer support and online sales." It was [acquired](https://www.crunchbase.com/organization/jivosite) by Sber in 2021.