### PR TITLE
Update DNS resolver list in category-doh

### DIFF
--- a/data/category-doh
+++ b/data/category-doh
@@ -5,6 +5,7 @@
 # Data sources:
 ## https://raw.githubusercontent.com/hagezi/dns-blocklists/master/domains/doh.txt
 ## https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/master/doh-domains.txt 
+## https://github.com/curl/curl/wiki/DNS-over-HTTPS
 ## + SubjectAlternativeName from SSL certificates
 
 # Cloudflare DNS
@@ -15,8 +16,8 @@ domain:cloudflare-dns.com
 # Google DNS
 full:dns.google
 full:8888.google
+full:dns.google.com
 full:dns64.dns.google
-domain:dns.google.com
 
 # Mullvad
 domain:dns.mullvad.net
@@ -28,38 +29,34 @@ domain:public-resolver.mullvad.net
 domain:dns.nextdns.io
 domain:dns1.nextdns.io
 domain:dns2.nextdns.io
-domain:edge.nextdns.io
-domain:steering.nextdns.io
 
 # ControlD
-domain:dns.controld.com
 domain:dns.controld.net
-domain:freedns.controld.com
+domain:dns.controld.com
 domain:freedns.controld.net
+domain:freedns.controld.com
 
 # Cisco OpenDNS
-domain:dns.opendns.com
-domain:doh.opendns.com
-domain:pdns.opendns.com
-domain:dns64.opendns.com
-domain:dns7071.opendns.com
-domain:resolver1.opendns.com
-domain:resolver2.opendns.com
-domain:familyshield.opendns.com
+full:dns.opendns.com
+full:doh.opendns.com
+full:pdns.opendns.com
+full:dns7071.opendns.com
+full:resolver1.opendns.com
+full:resolver2.opendns.com
+full:familyshield.opendns.com
+full:doh.familyshield.opendns.com
 
 # Cisco Umbrella
-domain:dns.umbrella.com
-domain:doh.umbrella.com
-domain:pdns.umbrella.com
-domain:dns64.umbrella.com
-domain:dns7071.umbrella.com
+full:dns.umbrella.com
+full:doh.umbrella.com
+full:pdns.umbrella.com
+full:dns7071.umbrella.com
 
 # Cisco SSE
-domain:dns.sse.cisco.com
-domain:doh.sse.cisco.com
-domain:dns64.sse.cisco.com
-domain:dns7071.sse.cisco.com
-domain:familyshield.sse.cisco.com
+full:dns.sse.cisco.com
+full:doh.sse.cisco.com
+full:dns7071.sse.cisco.com
+full:familyshield.sse.cisco.com
 
 # Quad9 DNS
 full:dns.quad9.net
@@ -82,11 +79,7 @@ full:dns-family.adguard.com
 full:dns-unfiltered.adguard.com
 
 # Yandex DNS
-domain:dns.yandex.by
-domain:dns.yandex.kz
-domain:dns.yandex.ru
-domain:dns.yandex.net
-domain:dns.yandex.com
+domain:dot.dns.yandex.net
 
 # CleanBrowsing (unfortunately, we have to block the entire domain)
 domain:cleanbrowsing.org

--- a/data/category-doh
+++ b/data/category-doh
@@ -9,12 +9,13 @@
 
 # Cloudflare DNS
 full:one.one.one.one
+full:dns.cloudflare.com
 domain:cloudflare-dns.com
-domain:dns.cloudflare.com
 
 # Google DNS
+full:dns.google
 full:8888.google
-domain:dns.google
+full:dns64.dns.google
 domain:dns.google.com
 
 # Mullvad
@@ -61,37 +62,37 @@ domain:dns7071.sse.cisco.com
 domain:familyshield.sse.cisco.com
 
 # Quad9 DNS
-domain:dns.quad9.net
-domain:dns9.quad9.net
-domain:dns10.quad9.net
-domain:dns11.quad9.net
-domain:dns12.quad9.net
-domain:dns13.quad9.net
-domain:dns254.quad9.net
-domain:dns-nosec.quad9.net
-domain:doh-brave.quad9.net
-domain:doh-chrome.quad9.net
-domain:doh-mozilla.quad9.net
-domain:dns.resolver.quad9.net
+full:dns.quad9.net
+full:dns9.quad9.net
+full:dns10.quad9.net
+full:dns11.quad9.net
+full:dns12.quad9.net
+full:dns13.quad9.net
+full:dns254.quad9.net
+full:dns-nosec.quad9.net
+full:doh-brave.quad9.net
+full:doh-chrome.quad9.net
+full:doh-mozilla.quad9.net
+full:dns.resolver.quad9.net
 
 # AdGuard DNS
 domain:adguard-dns.com
-domain:dns.adguard.com
-domain:dns-family.adguard.com
-domain:dns-unfiltered.adguard.com
+full:dns.adguard.com
+full:dns-family.adguard.com
+full:dns-unfiltered.adguard.com
 
 # Yandex DNS
 domain:dns.yandex.by
 domain:dns.yandex.kz
 domain:dns.yandex.ru
-domain:dns.yandex.com
 domain:dns.yandex.net
+domain:dns.yandex.com
 
 # CleanBrowsing (unfortunately, we have to block the entire domain)
 domain:cleanbrowsing.org
 
 # Wikimedia DNS
-domain:wikimedia-dns.org
+full:wikimedia-dns.org
 
 # Ali DNS
 full:dns.alidns.com

--- a/data/category-doh
+++ b/data/category-doh
@@ -2,17 +2,96 @@
 
 # **Public anycast resolvers**
 
+# Data sources:
+## https://raw.githubusercontent.com/hagezi/dns-blocklists/master/domains/doh.txt
+## https://raw.githubusercontent.com/dibdot/DoH-IP-blocklists/master/doh-domains.txt 
+## + SubjectAlternativeName from SSL certificates
+
+# Cloudflare DNS
+full:one.one.one.one
+domain:cloudflare-dns.com
+domain:dns.cloudflare.com
+
+# Google DNS
+full:8888.google
+domain:dns.google
+domain:dns.google.com
+
+# Mullvad
+domain:dns.mullvad.net
+domain:doh.mullvad.net
+domain:dot.mullvad.net
+domain:public-resolver.mullvad.net
+
+# NextDNS
+domain:dns.nextdns.io
+domain:dns1.nextdns.io
+domain:dns2.nextdns.io
+domain:edge.nextdns.io
+domain:steering.nextdns.io
+
+# ControlD
+domain:dns.controld.com
+domain:dns.controld.net
+domain:freedns.controld.com
+domain:freedns.controld.net
+
+# Cisco OpenDNS
+domain:dns.opendns.com
+domain:doh.opendns.com
+domain:pdns.opendns.com
+domain:dns64.opendns.com
+domain:dns7071.opendns.com
+domain:resolver1.opendns.com
+domain:resolver2.opendns.com
+domain:familyshield.opendns.com
+
+# Cisco Umbrella
+domain:dns.umbrella.com
+domain:doh.umbrella.com
+domain:pdns.umbrella.com
+domain:dns64.umbrella.com
+domain:dns7071.umbrella.com
+
+# Cisco SSE
+domain:dns.sse.cisco.com
+domain:doh.sse.cisco.com
+domain:dns64.sse.cisco.com
+domain:dns7071.sse.cisco.com
+domain:familyshield.sse.cisco.com
+
+# Quad9 DNS
+domain:dns.quad9.net
+domain:dns9.quad9.net
+domain:dns10.quad9.net
+domain:dns11.quad9.net
+domain:dns12.quad9.net
+domain:dns13.quad9.net
+domain:dns254.quad9.net
+domain:dns-nosec.quad9.net
+domain:doh-brave.quad9.net
+domain:doh-chrome.quad9.net
+domain:doh-mozilla.quad9.net
+domain:dns.resolver.quad9.net
+
 # AdGuard DNS
+domain:adguard-dns.com
+domain:dns.adguard.com
+domain:dns-family.adguard.com
+domain:dns-unfiltered.adguard.com
 
-## Default
-full:dns.adguard.com
-full:dns.adguard-dns.com
+# Yandex DNS
+domain:dns.yandex.by
+domain:dns.yandex.kz
+domain:dns.yandex.ru
+domain:dns.yandex.com
+domain:dns.yandex.net
 
-## Family Protection
-full:family.adguard-dns.com
+# CleanBrowsing (unfortunately, we have to block the entire domain)
+domain:cleanbrowsing.org
 
-## Non-filtering
-full:unfiltered.adguard-dns.com
+# Wikimedia DNS
+domain:wikimedia-dns.org
 
 # Ali DNS
 full:dns.alidns.com
@@ -36,20 +115,6 @@ full:internetsehat.bebasid.com
 
 # CFIEC Public DNS
 full:dns.cfiec.net
-
-# Cisco OpenDNS
-opendns.com
-
-# CleanBrowsing
-full:doh.cleanbrowsing.org
-
-# Cloudflare DNS
-full:one.one.one.one
-full:dns.cloudflare.com
-cloudflare-dns.com
-
-# ControlD
-full:freedns.controld.com
 
 # DeCloudUs DNS
 full:dns.decloudus.com
@@ -98,34 +163,8 @@ full:sm2.doh.pub
 # dns0.eu
 full:zero.dns0.eu
 
-# Google DNS
-full:dns.google
-
 # Hurricane Electric Public Recursor
 full:ordns.he.net
-
-# Mullvad
-
-## Non-filtering
-full:dns.mullvad.net
-
-## Ad blocking
-full:adblock.dns.mullvad.net
-
-## Ad + malware blocking
-full:base.dns.mullvad.net
-
-## Ad + malware + social media blocking
-full:extended.dns.mullvad.net
-
-## Ad + malware + adult + gambling blocking
-full:family.dns.mullvad.net
-
-## Ad + malware + adult + gambling + social media blocking
-full:all.dns.mullvad.net
-
-# NextDNS
-nextdns.io
 
 # OpenBLD.net DNS
 
@@ -134,15 +173,6 @@ full:ada.openbld.net
 
 ## Strict Filtering (RIC)
 full:ric.openbld.net
-
-# Quad9 DNS
-
-## Standard
-full:dns.quad9.net
-
-## Unsecured
-full:dns10.quad9.net
-full:dns11.quad9.net
 
 # Quadrant Security
 full:doh.qis.io
@@ -171,9 +201,6 @@ full:dns.surfsharkdns.com
 
 # v.recipes DNS (former 0ms.dev)
 full:v.recipes
-
-# Wikimedia DNS
-full:wikimedia-dns.org
 
 # **Regional resolvers**
 
@@ -255,17 +282,6 @@ full:dns.seia.io
 
 ## Oracle Cloud South Korea
 full:secondary.dns.seia.io
-
-# Yandex DNS
-
-## Basic
-full:common.dot.dns.yandex.net
-
-## Safe
-full:safe.dot.dns.yandex.net
-
-## Family
-full:family.dot.dns.yandex.net
 
 # **Small personal resolvers**
 


### PR DESCRIPTION
Hi. I’ve researched the most popular DNS providers and compiled a list of domains.

The servers listed are for:

- Cloudflare
- Google
- Mullvad
- NextDNS
- ControlD
- Cisco OpenDNS / Umbrella / SSE
- Quad9
- AdGuard
- Yandex
- CleanBrowsing
- Wikimedia DNS

Data sources:

- https://github.com/hagezi/dns-blocklists (22K Stars)
- https://github.com/dibdot/DoH-IP-blocklists (300 Stars)
- SubjectAlternativeName from SSL certificates

I’d appreciate it if you could add them. Thanks!