### PR TITLE
category-dev: added snapcraft

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -43,12 +43,13 @@ include:polymer
 include:python
 include:qt
 include:readthedocs
+include:redhat
 include:redis
 include:ruby
 include:rust
-include:redhat
 include:scala
 include:sentry
+include:snapcraft
 include:sourcehut
 include:stackexchange
 include:strikingly


### PR DESCRIPTION
Found this in the `canonical`, which is already included. Closed.