### PR TITLE
category-ip-geo-detect: add ip.comss.net

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -136,6 +136,7 @@ wtfismyip.com
 full:checkip.amazonaws.com
 full:ipv4-check-perf.radar.cloudflare.com
 full:ipv6-check-perf.radar.cloudflare.com
+full:ip.comss.net
 geoip.noc.gov.ru
 ip.hetzner.com
 ip.mail.ru


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

