### PR TITLE
category-ru: add apptrackpets.com

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -65,6 +65,7 @@ xn--80aj3b.xn--p1ai # ета.рф
 xn--80arpq.xn--p1ai # йота.рф
 
 # Other domains
+apptrackpets.com # Pet GPS tracker service (Yandex Cloud, reg.ru)
 gazfond-pn.ru    # Non-state pension fund GAZFOND pension savings
 litres.ru        # E-book and audiobook service
 meteoinfo.ru     # Hydrometeorological Center of Russia


### PR DESCRIPTION
## Summary

Add `apptrackpets.com` to `category-ru`.

**apptrackpets.com** is a Russian pet GPS tracker service.

Evidence:
- **IP:** 158.160.29.227 (Yandex Cloud)
- **Registrar:** reg.ru
- **NS:** ns1.yandexcloud.net, ns2.yandexcloud.net