### PR TITLE
fedora: add fedorainfracloud.org

### DIFF
--- a/data/fedora
+++ b/data/fedora
@@ -1,5 +1,6 @@
-getfedora.org
 fedoraforum.org
+fedorainfracloud.org
+fedoramagazine.org
 fedorapeople.org
 fedoraproject.org
-fedoramagazine.org
+getfedora.org


### PR DESCRIPTION
Added `fedorainfracloud.org`, which is used for [Fedora Copr](https://copr.fedorainfracloud.org/coprs/).