### PR TITLE
Create headhunter

### DIFF
--- a/data/category-companies
+++ b/data/category-companies
@@ -35,6 +35,7 @@ include:gigabyte
 include:gmo-internet
 include:godaddy
 include:google
+include:headhunter
 include:hetzner
 include:hinet
 include:hkbn

--- a/data/category-ru
+++ b/data/category-ru
@@ -12,6 +12,7 @@ include:category-travel-ru
 
 # Russian companies
 include:carrotquest
+include:headhunter
 include:kaspersky
 include:mailru-group
 include:mindbox

--- a/data/headhunter
+++ b/data/headhunter
@@ -1,0 +1,8 @@
+hh.by
+hh.kz
+hh.ru
+hhcdn.ru
+rabota.by
+setka.ru
+talantix.ru
+zarplata.ru


### PR DESCRIPTION
Added [HeadHunter](https://hh.ru/article/28), a Russian company focused on online recruiting. This request includes core platforms, static/CDN and HeadHunter-owned services. It's also added to `category-companies` and `category-ru`.