### PR TITLE
category-ru: add include:category-media-ru

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -8,6 +8,7 @@ include:category-entertainment-ru
 include:category-gov-ru
 include:category-medicine-ru
 include:category-retail-ru
+include:category-media-ru
 include:category-travel-ru
 
 # Russian companies


### PR DESCRIPTION
## Summary

Add `include:category-media-ru` to `category-ru`.

Currently, `category-ru` includes several Russian subcategories:
- `category-ecommerce-ru`
- `category-entertainment-ru`
- `category-gov-ru`
- `category-medicine-ru`
- `category-retail-ru`
- `category-travel-ru`

However, `category-media-ru` is missing. This means ~130 Russian media domains (meduza.io, novayagazeta.ru, tvrain.tv, mediazona.ca, holod.media, etc.) are not reachable via `geosite:category-ru`.

This PR adds the missing include so that Russian media outlets are part of the broader Russian domain routing category.