### PR TITLE
Update Russian websites

### DIFF
--- a/data/category-bank-ru
+++ b/data/category-bank-ru
@@ -14,6 +14,7 @@ broker.ru
 gazprombank.com
 gazprombank.investments
 gazprombank.ru
+gid.ru
 gpb.ru
 
 # MKB

--- a/data/category-bank-ru
+++ b/data/category-bank-ru
@@ -1,6 +1,3 @@
-include:sber
-include:tbank-ru
-
 # Alfa Bank
 alfabank.ru
 alfabank.st
@@ -37,6 +34,12 @@ abr.ru
 
 # Russian Agricultural Bank
 rshb.ru
+
+# SberBank
+include:sber
+
+# T-Bank (Tinkoff) and RosBank
+include:tbank-ru
 
 # Tochka bank
 tochka-tech.com

--- a/data/category-gov-ru
+++ b/data/category-gov-ru
@@ -43,7 +43,6 @@ mos.ru          # Moscow
 mosreg.ru       # Moscow Region
 spb.ru          # St. Petersburg
 sevastopol.ru   # Sevastopol
-sev.ru          # Sevastopol
 
 # Republics
 adygeya.ru      # Republic of Adygea

--- a/data/category-travel-ru
+++ b/data/category-travel-ru
@@ -10,8 +10,9 @@ avtovokzaly.ru
 # Ostrovok
 ostrovok.ru
 
-# Othello
-include:sber
+# Othello / Otello from 2GIS and Sber
+otello.ru
+sber.ru
 
 # Public transport and ticketing
 include:mosmetro

--- a/data/category-travel-ru
+++ b/data/category-travel-ru
@@ -10,6 +10,9 @@ avtovokzaly.ru
 # Ostrovok
 ostrovok.ru
 
+# Othello
+include:sber
+
 # Public transport and ticketing
 include:mosmetro
 full:bilet.nspk.ru

--- a/data/category-travel-ru
+++ b/data/category-travel-ru
@@ -11,6 +11,7 @@ avtovokzaly.ru
 ostrovok.ru
 
 # Othello / Otello from 2GIS and Sber
+2gis.ru
 otello.ru
 sber.ru
 

--- a/data/category-travel-ru
+++ b/data/category-travel-ru
@@ -35,3 +35,4 @@ full:arenda.yandex.ru
 
 # Yandex Taxi
 full:taxi.yandex.ru
+fasten.ru

--- a/data/mailru-group
+++ b/data/mailru-group
@@ -93,6 +93,7 @@ domain:xray.mail.ru @ads
 
 # CDNs
 appsmail.ru
+attachmail.ru
 attachmy.com
 bizmrg.com
 cdnmail.ru
@@ -114,6 +115,7 @@ bk.ru
 inbox.ru
 internet.ru
 list.ru
+xmail.ru
 
 ## All Cups
 cups.online

--- a/data/mailru-group
+++ b/data/mailru-group
@@ -208,11 +208,11 @@ oneme.ru
 sferum-dev.ru
 sferum.ru
 
-## my.com
+## myMail
 dev-my.com
 my.com
 
-## my.games (formally left Russian market)
+## My.Games (formally left Russian market)
 dev-my.games
 it-territory.com
 knightspeak.com

--- a/data/mailru-group
+++ b/data/mailru-group
@@ -208,7 +208,7 @@ oneme.ru
 sferum-dev.ru
 sferum.ru
 
-## myMail
+## My.com, myMail
 dev-my.com
 my.com
 


### PR DESCRIPTION
category-gov-ru
- sev.ru: Remove a domain that doesn't belong to a federal city. The domain belongs to the energy company Sapsan Energia.

category-travel-ru
- Add Othello
- Add Fasten

category-bank-ru
- Add a comment for SberBank and T-Bank

mailru-group
- Add a missing mail.ru email domain
- Update comments for myMail and My.Games
