### PR TITLE
ozon: remove some problematic ad domains

### DIFF
--- a/data/ozon
+++ b/data/ozon
@@ -55,7 +55,6 @@ domain:new-adv.ozon.ru @ads
 domain:prodvizhenie-adv.ozon.ru @ads
 domain:questions-adv.ozon.ru @ads
 domain:sentry.ozon.ru @ads
-domain:tracking.ocourier.ru @ads
 domain:xapi.ozon.by @ads
 domain:xapi.ozon.com @ads
 domain:xapi.ozon.com.by @ads

--- a/data/ozon
+++ b/data/ozon
@@ -56,8 +56,6 @@ domain:prodvizhenie-adv.ozon.ru @ads
 domain:questions-adv.ozon.ru @ads
 domain:sentry.ozon.ru @ads
 domain:tracking.ocourier.ru @ads
-domain:tracking.ozon-dostavka.ru @ads
-domain:tracking.ozon.ru @ads
 domain:xapi.ozon.by @ads
 domain:xapi.ozon.com @ads
 domain:xapi.ozon.com.by @ads


### PR DESCRIPTION
Remove 'tracking.ozon-dostavka.ru' and 'tracking.ozon.ru' from @ads. This domains for package delivery tracking system not ads or user tracking.