### PR TITLE
archlinux: add archlinux.de

### DIFF
--- a/data/archlinux
+++ b/data/archlinux
@@ -1,3 +1,4 @@
+archlinux.de
 archlinux.org
 archlinuxarm.org
 pkgbuild.com


### PR DESCRIPTION
Some Arch Linux websites are hosted on this domain, such as `pkgstats.archlinux.de`.
