### PR TITLE
Create ucoz

### DIFF
--- a/data/category-companies
+++ b/data/category-companies
@@ -92,6 +92,7 @@ include:theboringcompany
 include:tonec
 include:uber
 include:ubiquiti
+include:ucoz
 include:verisign
 include:verizon
 include:vultr

--- a/data/category-ru
+++ b/data/category-ru
@@ -17,6 +17,7 @@ include:kaspersky
 include:mailru-group
 include:mindbox
 include:selectel
+include:ucoz-ru
 include:whoosh
 include:yandex
 

--- a/data/ucoz
+++ b/data/ucoz
@@ -1,0 +1,39 @@
+# ucoz
+
+include:ucoz-ru
+ucoz.ae
+ucoz.club
+ucoz.co
+ucoz.co.il
+ucoz.co.uk
+ucoz.com
+ucoz.com.br
+ucoz.com.ro
+ucoz.de
+ucoz.es
+ucoz.fr
+ucoz.hu
+ucoz.kz
+ucoz.lv
+ucoz.md
+ucoz.net
+ucoz.org
+ucoz.pl
+ucoz.site
+ucoz.ua
+
+# ucozmedia
+
+ucozmedia.com
+
+# ukit
+
+ukit.ai
+ukit.com
+ukit.group
+ukit.me
+
+# other
+
+at.ua
+ucoztemplates.com

--- a/data/ucoz-ru
+++ b/data/ucoz-ru
@@ -1,0 +1,4 @@
+scripts-for-ucoz.ru
+ucoz.ru
+ucozmedia.ru
+uguide.ru


### PR DESCRIPTION
uCoz is a Russian SaaS web hosting. The same legal entity owns uKit website builder. There are many websites with its subdomains.

Domains are sourced from search engines and verified with BGP toolkit for the presence of uCoz NS, MX records. I've added it to `category:companies`, but I'm not sure if it should also go in `category-ru`.