### PR TITLE
Add more Russian service domains

### DIFF
--- a/data/betboom
+++ b/data/betboom
@@ -1,0 +1,2 @@
+betboom.ru
+mobile-bb.com

--- a/data/category-betting-ru
+++ b/data/category-betting-ru
@@ -1,0 +1,4 @@
+include:betboom
+include:fonbet
+include:ligastavok
+include:winline

--- a/data/category-retail-ru
+++ b/data/category-retail-ru
@@ -36,11 +36,17 @@ fix-price.com
 lenta.com
 lenta.tech
 
-# Magnet
-magnit.ru
+# Magnit
+include:magnit
+
+# M.Video
+include:mvideo
 
 # Metro
 metro-cc.ru
+
+# OSKELLY
+include:oskelly
 
 # Pyaterochka, Perekrestok, Chizhik
 include:x5
@@ -58,6 +64,9 @@ ilovesakura.ru
 
 # Spar
 myspar.ru
+
+# SOKOLOV
+include:sokolov
 
 # Sushi Wok
 sushiwok.ru

--- a/data/category-ru
+++ b/data/category-ru
@@ -11,13 +11,16 @@ include:category-retail-ru
 include:category-travel-ru
 
 # Russian companies
+include:betboom
 include:carrotquest
+include:fonbet
 include:headhunter
 include:kaspersky
 include:mailru-group
 include:mindbox
 include:selectel
 include:whoosh
+include:winline
 include:yandex
 
 # Bank & Finance & Insurance & Securities

--- a/data/category-ru
+++ b/data/category-ru
@@ -16,6 +16,7 @@ include:carrotquest
 include:fonbet
 include:headhunter
 include:kaspersky
+include:ligastavok
 include:mailru-group
 include:mindbox
 include:selectel

--- a/data/category-ru
+++ b/data/category-ru
@@ -3,6 +3,7 @@ ru.com
 ru.net
 
 include:tld-ru
+include:category-betting-ru
 include:category-ecommerce-ru
 include:category-entertainment-ru
 include:category-gov-ru
@@ -11,17 +12,13 @@ include:category-retail-ru
 include:category-travel-ru
 
 # Russian companies
-include:betboom
 include:carrotquest
-include:fonbet
 include:headhunter
 include:kaspersky
-include:ligastavok
 include:mailru-group
 include:mindbox
 include:selectel
 include:whoosh
-include:winline
 include:yandex
 
 # Bank & Finance & Insurance & Securities

--- a/data/fonbet
+++ b/data/fonbet
@@ -1,0 +1,4 @@
+bk6bba-resources.com
+bk6bba-resources.ru
+fon.bet
+fon.promo

--- a/data/ligastavok
+++ b/data/ligastavok
@@ -1,0 +1,4 @@
+ligadobra.ru
+ligastavok-csr.ru
+ligastavok.ru
+sozvezdie-dobra.ru

--- a/data/magnit
+++ b/data/magnit
@@ -1,0 +1,3 @@
+kazanexpress.ru
+magnit.ru
+mm.ru

--- a/data/mvideo
+++ b/data/mvideo
@@ -1,3 +1,3 @@
 acmvid.com
-full:mvideo.edna.io
 mvideo.ru
+full:mvideo.edna.io

--- a/data/mvideo
+++ b/data/mvideo
@@ -1,0 +1,3 @@
+acmvid.com
+full:mvideo.edna.io
+mvideo.ru

--- a/data/okko
+++ b/data/okko
@@ -1,3 +1,4 @@
+okkoapi.tv
 playfamily.ru
 okko.sport
 okko.tv

--- a/data/oskelly
+++ b/data/oskelly
@@ -1,0 +1,2 @@
+oskelly.co
+oskelly.ru

--- a/data/sokolov
+++ b/data/sokolov
@@ -1,0 +1,2 @@
+sokolov.io
+sokolov.ru

--- a/data/winline
+++ b/data/winline
@@ -1,0 +1,3 @@
+win-line.ru
+winline.ru
+winlinebet.ru


### PR DESCRIPTION
Add dedicated lists for BetBoom, Fonbet, Liga Stavok, Winline, M.Video, OSKELLY, SOKOLOV, and Magnit.

Changes:
- add new `betboom`, `fonbet`, `ligastavok`, `winline`, `mvideo`, `oskelly`, `sokolov`, and `magnit` lists
- add new `category-betting-ru` and include betting services there
- include `category-betting-ru` in `category-ru`
- add `okkoapi.tv` to the existing `okko` list
- include retail services in `category-retail-ru`

Validation:
- `go run ./ --datapath=./data --outputdir=/tmp/dlc-russian-services-2-betting`