### PR TITLE
Add more category-ip-geo-detect domains

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -87,15 +87,18 @@ iproyal.com
 ipstack.com
 ipverify.com
 ipw.cn @cn
+ipwho.is
 ipwhois.io
 ipxapi.com
 l2.io
 maxmind.com
 mon-ip.com
 monip.org
+my-ip.io
 my.ipinfo.app
 myexternalip.com
 myip.com
+myip.expert
 myip.ms
 myip.ru
 myip.wtf


### PR DESCRIPTION
Closes #3480.

Add `myip.expert`, `ipwho.is`, and `my-ip.io` to `category-ip-geo-detect`.

Validation:
- `go run ./ --datapath=./data --outputdir=/tmp/dlc-ip-geo-detect`