### PR TITLE
Add scorecardresearch.com to geolocation-!cn

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -7,6 +7,8 @@ include:category-ai-!cn
 include:pubmatic
 include:taboola
 
+scorecardresearch.com
+
 # Anti-censorship & Anti-GFW & Privacy protection & VPN tools
 include:category-anticensorship
 include:category-proxy-tunnels


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

"ScorecardResearch conducts research by collecting Internet web browsing data and then uses that data to help show how people use the Internet, what they like about it, and what they don't."
Observed in browsers