### PR TITLE
add ACP to category-ai-!cn

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -30,6 +30,7 @@ cohere.com
 clipdrop.co
 jasper.ai
 
+agentclientprotocol.com
 chutes.ai
 clawhub.ai
 copilot.microsoft.com


### PR DESCRIPTION
https://agentclientprotocol.com
https://github.com/agentclientprotocol

The ACP [registry](https://agentclientprotocol.com/get-started/registry) is used in Zed and in Jetbrains products.

