### PR TITLE
geolocation-cn: add qianxin and threatbook domains

### DIFF
--- a/data/category-ai-cn
+++ b/data/category-ai-cn
@@ -92,5 +92,8 @@ clawhub-mirror.com
 # Skillhub (tencent)
 skillhub.cn
 
+# SafeSkill (微步在线)
+safeskill.cn
+
 # 智合 AI 沪ICP备2024060320号-4
 zhiexa.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -519,6 +519,7 @@ include:midea
 include:narwal # 云鲸科技
 include:netease @-!cn
 include:oppo @-!cn
+include:qianxin
 include:qihoo360
 include:sumkoo #北京尚古创新科技有限公司
 include:tcl
@@ -1701,12 +1702,3 @@ safeskill.cn
 threatbook.cn
 onedns.net # OneDNS
 shellpub.com
-
-# 奇安信 奇安信科技集团股份有限公司 京ICP备16020626号
-qianxin.com
-qianxincdn.com
-95015.com
-ceati.org.cn # CEATI 联盟
-seclab.online # SecLab
-datacon.org.cn # DataCon
-tianshucup.com # 天枢杯

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -463,8 +463,6 @@ zhangyuecdn.com
 moseeker.com
 ## 小能智慧云客服
 ntalker.com
-## OneDNS 微步在线
-onedns.net
 ## 心知天气
 sencdn.com
 seniverse.com
@@ -1694,3 +1692,21 @@ wanji.net.cn
 
 # 广州市雅望互联网服务有限公司
 gzyowin.com
+
+# 微步在线
+# 北京步刻科技有限公司 京ICP备2022014156号
+threatbook.com # ThreatBook
+safeskill.cn
+# 北京微步在线科技有限公司 京ICP备15044984号
+threatbook.cn
+onedns.net # OneDNS
+shellpub.com
+
+# 奇安信 奇安信科技集团股份有限公司 京ICP备16020626号
+qianxin.com
+qianxincdn.com
+95015.com
+ceati.org.cn # CEATI 联盟
+seclab.online # SecLab
+datacon.org.cn # DataCon
+tianshucup.com # 天枢杯

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -546,23 +546,29 @@ suzuki-china.com # 铃木中国官网
 udesk.cn # 沃丰科技
 ysjf.com # 影视飓风
 
-# 飞牛
+## 飞牛
 fnnas.com
 fnnas.net
 fnos.net
-# 稿定（厦门）信息服务有限公司
-## 花瓣网 闽ICP备2021013850号
+## 稿定（厦门）信息服务有限公司
+### 花瓣网 闽ICP备2021013850号
 huaban.com
 huabanimg.com
-## 闽ICP备12002004号
+### 闽ICP备12002004号
 dancf.com
 hlgdata.com
 huanleguang.com
 ttxsapp.com.cn
 xsbapp.cn
-# 凯迪仕
+## 凯迪仕
 juziwulian.com
 kaadas.com
+## 微步在线 / 步刻科技
+onedns.net
+#safeskill.cn
+shellpub.com
+threatbook.cn
+threatbook.com
 
 # Telecommunication
 include:chinabroadnet
@@ -1693,12 +1699,3 @@ wanji.net.cn
 
 # 广州市雅望互联网服务有限公司
 gzyowin.com
-
-# 微步在线
-# 北京步刻科技有限公司 京ICP备2022014156号
-threatbook.com # ThreatBook
-safeskill.cn
-# 北京微步在线科技有限公司 京ICP备15044984号
-threatbook.cn
-onedns.net # OneDNS
-shellpub.com

--- a/data/qianxin
+++ b/data/qianxin
@@ -1,0 +1,8 @@
+# 奇安信 奇安信科技集团股份有限公司 京ICP备16020626号
+95015.com
+ceati.org.cn # CEATI 联盟
+datacon.org.cn # DataCon
+qianxin.com
+qianxincdn.com
+seclab.online # SecLab
+tianshucup.com # 天枢杯


### PR DESCRIPTION
Add some registered, resolvable and reliable domains from [Qianxin](https://www.qianxin.com/) and [ThreatBook](https://www.threatbook.cn/) to `geolocation-cn`.

<details>
  <summary>ICP Infos</summary>

<img width="1000" height="270" alt="image" src="https://github.com/user-attachments/assets/ce6ee391-419a-4dac-8b08-08fe1d0f9b93" />

<img width="1000" height="580" alt="image" src="https://github.com/user-attachments/assets/2491ce31-b39e-4bdb-9a51-da69c452d3e4" />

<img width="1000" height="530" alt="image" src="https://github.com/user-attachments/assets/889f93c8-a2b1-4d5a-8558-c8fb0640451c" />

</details>

<details>
  <summary>ITDOG</summary>

<img width="1100" height="1200" alt="image" src="https://github.com/user-attachments/assets/0489eb46-f287-48e5-aad3-2ecce635026b" />

</details>

