### PR TITLE
Revert "Update meta to include manus"

### DIFF
--- a/data/meta
+++ b/data/meta
@@ -1,7 +1,6 @@
 include:facebook
 include:facebook-dev
 include:instagram
-include:manus
 include:messenger
 include:oculus
 include:threads


### PR DESCRIPTION
Reverts v2fly/domain-list-community#3488

Reason: https://www.wsj.com/tech/ai/meta-is-preparing-to-have-to-undo-its-manus-acquisition-after-china-ban-a4ffbefb