### PR TITLE
Add digitalocean-ui.com to the list

### DIFF
--- a/data/digitalocean
+++ b/data/digitalocean
@@ -1,4 +1,5 @@
 digitalocean.com
+digitalocean-ui.com
 digitaloceanspaces.com
 do.co
 nginxconfig.io


### PR DESCRIPTION
It seems like DO moved some of their static to a separate domain, couldn't open “cloud.digitalocean.com” (specifically, /login section) until added this domain (found via network devtools) manually.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

