### PR TITLE
Update github & github-copilot

### DIFF
--- a/data/github
+++ b/data/github
@@ -26,13 +26,37 @@ opensource.guide
 repo.new
 thegithubshop.com
 
-# GitHub Actions Artifacts
-blob.core.windows.net
-
 full:github-api.arkoselabs.com
+
+# Amazon S3
 full:github-cloud.s3.amazonaws.com
-regexp:^github-production-release-asset-[0-9a-zA-Z]{6}\.s3\.amazonaws\.com$
+full:github-production-release-asset-2e65be.s3.amazonaws.com
+full:github-production-repository-file-5c1aeb.s3.amazonaws.com
+full:github-production-repository-image-32fea6.s3.amazonaws.com
+full:github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+full:github-production-user-asset-6210df.s3.amazonaws.com
+
+# Azure Blob Storage
+full:productionresultssa0.blob.core.windows.net
+full:productionresultssa1.blob.core.windows.net
+full:productionresultssa2.blob.core.windows.net
+full:productionresultssa3.blob.core.windows.net
+full:productionresultssa4.blob.core.windows.net
+full:productionresultssa5.blob.core.windows.net
+full:productionresultssa6.blob.core.windows.net
+full:productionresultssa7.blob.core.windows.net
+full:productionresultssa8.blob.core.windows.net
+full:productionresultssa9.blob.core.windows.net
+full:productionresultssa10.blob.core.windows.net
+full:productionresultssa11.blob.core.windows.net
+full:productionresultssa12.blob.core.windows.net
+full:productionresultssa13.blob.core.windows.net
+full:productionresultssa14.blob.core.windows.net
+full:productionresultssa15.blob.core.windows.net
+full:productionresultssa16.blob.core.windows.net
+full:productionresultssa17.blob.core.windows.net
+full:productionresultssa18.blob.core.windows.net
+full:productionresultssa19.blob.core.windows.net
 
 # Ads/tracking
 collector.github.com @ads
-copilot-telemetry.githubusercontent.com @ads

--- a/data/github-copilot
+++ b/data/github-copilot
@@ -1,1 +1,10 @@
 githubcopilot.com
+
+full:copilot-proxy.githubusercontent.com
+full:copilot-workspace.githubnext.com
+
+# Azure Blob Storage
+full:copilotprodattachments.blob.core.windows.net
+
+# Ads
+copilot-telemetry.githubusercontent.com @ads

--- a/data/github-copilot
+++ b/data/github-copilot
@@ -6,5 +6,6 @@ full:copilot-workspace.githubnext.com
 # Azure Blob Storage
 full:copilotprodattachments.blob.core.windows.net
 
-# Ads
-copilot-telemetry.githubusercontent.com @ads
+# Ads/tracking
+full:copilot-telemetry-service.githubusercontent.com @ads
+full:copilot-telemetry.githubusercontent.com @ads


### PR DESCRIPTION
The regex matching for `^github-production-release-asset-[0-9a-zA-Z]{6}\.s3\.amazonaws\.com$` is inaccurate; GitHub does not utilize any domains matching this pattern other than `github-production-release-asset-2e65be.s3.amazonaws.com`. Since Amazon S3 bucket naming requires no verification, an overly broad matching range could lead to unintended behavior.

The same logic applies to the matching of `blob.core.windows.net`, as all Azure Blob Storage accounts share the same domain suffix.