### PR TITLE
digitalocean: add ondigitalocean.com

### DIFF
--- a/data/digitalocean
+++ b/data/digitalocean
@@ -1,5 +1,5 @@
 digitalocean.com
 digitaloceanspaces.com
-ondigitalocean.com
 do.co
 nginxconfig.io
+ondigitalocean.com

--- a/data/digitalocean
+++ b/data/digitalocean
@@ -1,4 +1,5 @@
 digitalocean.com
 digitaloceanspaces.com
+ondigitalocean.com
 do.co
 nginxconfig.io


### PR DESCRIPTION
## Summary

Add `ondigitalocean.com` to the `data/digitalocean` file.

## Motivation

Many DigitalOcean managed resources are hosted under the `ondigitalocean.com` domain. For example:

- **Managed Databases** (MongoDB, PostgreSQL, MySQL, Redis, etc.) expose connection endpoints like `mydb.mongo.ondigitalocean.com`
- Without this domain in the list, users who route traffic through proxy/VPN tools relying on this rule set will be unable to connect to their DO-managed resources via tools such as MongoDB Compass, `psql`, `redis-cli`, etc.
