### PR TITLE
category-ai-!cn: add openspec.dev

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -53,5 +53,6 @@ ollama.com
 openart.ai
 openclaw.ai
 openrouter.ai
+openspec.dev
 plannotator.ai
 spicywriter.com


### PR DESCRIPTION
> Spec-driven development (SDD) for AI coding assistants.

https://github.com/Fission-AI/OpenSpec
[openspec.dev/](https://openspec.dev/)
