### PR TITLE
Add Vodafone Netherlands domains to geosite:vodafone

### DIFF
--- a/data/vodafone
+++ b/data/vodafone
@@ -6,3 +6,4 @@ vodafone.com.au
 vodafone.com.tr
 vodafone.de
 vodafone.it
+vodafone.nl


### PR DESCRIPTION
Update geosite:vodafone.

Add official Vodafone Netherlands domains.