### PR TITLE
mailru-group: add new domains

### DIFF
--- a/data/mailru-group
+++ b/data/mailru-group
@@ -9,15 +9,12 @@ boom.ru
 boosty.to
 donationalerts.com
 hrtek.ru
-justveryok.com
 koddobra.ru
 lovina.app
 mail.ru
 mediumquality.ru
 memealerts.com
 movika.com
-rabbitcounter.com
-sayeasy.eu
 sportmail.ru
 summerstage.ru
 tamtam.chat
@@ -39,6 +36,12 @@ yclients.com
 # IDN ccTLD
 xn--80asgb.xn--p1ai # майл.рф
 xn--e1aigb.xn--p1ai # мейл.рф
+
+# Unknown-purpose domains with DGA subdomains
+justveryok.com
+keyboardmen.com
+rabbitcounter.com
+sayeasy.eu
 
 # Ads and tracking
 ad.mail.ru @ads

--- a/data/mailru-group
+++ b/data/mailru-group
@@ -9,12 +9,15 @@ boom.ru
 boosty.to
 donationalerts.com
 hrtek.ru
+justveryok.com
 koddobra.ru
 lovina.app
 mail.ru
 mediumquality.ru
 memealerts.com
 movika.com
+rabbitcounter.com
+sayeasy.eu
 sportmail.ru
 summerstage.ru
 tamtam.chat

--- a/data/ok
+++ b/data/ok
@@ -1,7 +1,15 @@
 apiok.ru
 insideok.ru
 odkl.ru
+odnoklasniki.by
+odnoklasniki.ua
+odnoklassniki.am
+odnoklassniki.by
+odnoklassniki.co.ee
+odnoklassniki.eu
+odnoklassniki.lv
 odnoklassniki.ru
+odnoklassniki.tj
 ok.me
 ok.ru
 okl.lt


### PR DESCRIPTION
I'm not sure what's the purpose of these domains, but I'm sure there're managed by VK:

1. These domains resolved only to IPs belonging to AS47764 (VK LLC).
2. `5.61.23.11`, `217.20.147.1`, `217.20.155.13` are used interchangeably by `odnoklassniki.ru` subdomains and these.

Accidentally found new OK domains too. 

**Source:** VirusTotal