### PR TITLE
category-ip-geo-detect: add new IP geolocation detection services

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -7,7 +7,6 @@ include:ipip
 abstractapi.com
 apiip.net
 apivoid.com
-beacondb.net
 bigdatacloud.net
 check-host.net
 checkip.org
@@ -142,6 +141,7 @@ wieistmeineip.de
 wtfismyip.com
 
 # Subdomains/internal api used for ip-geo-detect
+full:api.beacondb.net
 full:checkip.amazonaws.com
 full:checkip.dyndns.org
 full:checkip.dyn.com

--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -7,6 +7,7 @@ include:ipip
 abstractapi.com
 apiip.net
 apivoid.com
+beacondb.net
 bigdatacloud.net
 check-host.net
 checkip.org
@@ -65,6 +66,7 @@ ipapi.co
 ipapi.com
 ipapi.is
 ipbase.com
+ipbot.com
 ipcalf.com
 ipchicken.com
 ipdata.co
@@ -82,6 +84,7 @@ iplocate.io
 iplocation.com
 iplocation.io
 iplocation.net
+iplookup.it
 ipqualityscore.com
 ipquery.io
 ipregistry.co

--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -141,7 +141,6 @@ wieistmeineip.de
 wtfismyip.com
 
 # Subdomains/internal api used for ip-geo-detect
-full:api.beacondb.net
 full:checkip.amazonaws.com
 full:checkip.dyndns.org
 full:checkip.dyn.com


### PR DESCRIPTION
Add beacondb.net, ipbot.com, and iplookup.it to the IP geolocation detection category.