### PR TITLE
Create category-ads-ru

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -1,5 +1,4 @@
 # This file contains domains that clearly serving ads
-include:category-ads-ir
 
 include:acfun @ads
 include:adobe @ads

--- a/data/category-ads
+++ b/data/category-ads
@@ -1,5 +1,7 @@
 # This file contains domains that clearly serving ads
 
+include:category-ads-ir
+
 include:acfun @ads
 include:adobe @ads
 include:alibaba @ads

--- a/data/category-ads
+++ b/data/category-ads
@@ -1,6 +1,7 @@
 # This file contains domains that clearly serving ads
 
 include:category-ads-ir
+include:category-ads-ru
 
 include:acfun @ads
 include:adobe @ads

--- a/data/category-ads-all
+++ b/data/category-ads-all
@@ -1,6 +1,5 @@
 # This file contains domains of all ads providers, including both the domains that serves ads, and the domains of providers themselves.
 include:category-ads
-include:category-ads-ir
 include:category-ads-ru
 
 include:adjust

--- a/data/category-ads-all
+++ b/data/category-ads-all
@@ -1,5 +1,7 @@
 # This file contains domains of all ads providers, including both the domains that serves ads, and the domains of providers themselves.
 include:category-ads
+include:category-ads-ir
+include:category-ads-ru
 
 include:adjust
 include:clearbit

--- a/data/category-ads-all
+++ b/data/category-ads-all
@@ -1,6 +1,5 @@
 # This file contains domains of all ads providers, including both the domains that serves ads, and the domains of providers themselves.
 include:category-ads
-include:category-ads-ru
 
 include:adjust
 include:clearbit

--- a/data/category-ads-ru
+++ b/data/category-ads-ru
@@ -1,3 +1,4 @@
+# This file contains domains of Russian ads providers, including both the domains that serves ads, and the domains of providers themselves.
 include:carrotquest
 include:envybox
 include:mindbox

--- a/data/category-ads-ru
+++ b/data/category-ads-ru
@@ -1,0 +1,33 @@
+include:carrotquest
+include:envybox
+include:mindbox
+
+adsource.pro
+flocktory.com
+realweb.ru
+reddigital.ru
+roistat.com
+targetads.io
+
+# Internest Group
+addriver.ru
+admedia.ru
+adriver.by
+adriver.ru
+datariver.ru
+dsp-getloyal.com
+groupminteraction.ru
+internest.ru
+linkexchange.ru
+rle.ru
+soloway.ru
+vedro.ru
+vengo.ru
+xn--e1aahubrjdf.xn--p1ai # интернест.рф
+
+# Mobio
+feedwise.io
+mobidick.xyz
+mobio.ru
+mobioagency.com
+mobiogroup.com

--- a/data/category-ru
+++ b/data/category-ru
@@ -3,6 +3,7 @@ ru.com
 ru.net
 
 include:tld-ru
+include:category-ads-ru
 include:category-betting-ru
 include:category-ecommerce-ru
 include:category-entertainment-ru
@@ -14,10 +15,8 @@ include:category-travel-ru
 
 # Russian companies
 include:beget
-include:carrotquest
 include:cdek
 include:comssone
-include:envybox
 include:genotek-ru
 include:gismeteo
 include:group-ib
@@ -26,7 +25,6 @@ include:ideco-ru
 include:kaspersky
 include:kontur
 include:mailru-group
-include:mindbox
 include:myoffice-ru
 include:selectel
 include:skyeng
@@ -82,12 +80,6 @@ srv-hub.org        # Website buider
 t1.cloud           # Russian cloud storage provider
 taxsee.com         # Taxi for business (self-employed drivers)
 yourgood.app       # CRM for small business
-
-## Ads and tracking
-adriver.ru @ads
-flocktory.com @ads
-roistat.com @ads
-targetads.io @ads
 
 ## Planeta Zdorov'ya pharmacy
 planetazdorovo.ru


### PR DESCRIPTION
Created `category-ads-ru` and included it in `category-ru` and `category-ads-all`. I also moved `category-ads-ir` from `category-ads` to `category-ads-all`.

Source for domains: VirusTotal passive DNS replication history.