### PR TITLE
Merge ucoz and ucoz-ru

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -32,7 +32,7 @@ include:selectel
 include:skyeng
 include:tilda
 include:timeweb
-include:ucoz-ru
+include:ucoz
 include:whoosh
 include:yandex
 

--- a/data/ucoz
+++ b/data/ucoz
@@ -1,6 +1,5 @@
-# ucoz
+# uCoz, a Russian free web hosting with a built-in content management system
 
-include:ucoz-ru
 ucoz.ae
 ucoz.club
 ucoz.co
@@ -19,21 +18,30 @@ ucoz.md
 ucoz.net
 ucoz.org
 ucoz.pl
+ucoz.ru
 ucoz.site
 ucoz.ua
+ukoz.ru
 
-# ucozmedia
-
+# uCozmedia
 ucozmedia.com
+ucozmedia.ru
 
-# ukit
+# uGuide
+uguide.ru
+uguide.su
 
+# uKit
 ukit.ai
 ukit.com
 ukit.group
 ukit.me
 
-# other
-
+# Other
 at.ua
+narod.ru
+scripts-for-ucoz.ru
+ucozmail.com
 ucoztemplates.com
+usocial.pro
+uweb.ru

--- a/data/ucoz-ru
+++ b/data/ucoz-ru
@@ -1,4 +1,0 @@
-scripts-for-ucoz.ru
-ucoz.ru
-ucozmedia.ru
-uguide.ru


### PR DESCRIPTION
It was me initially who proposed to create a separate `ucoz-ru` file (#3478), but now I wanted to merge it with `ucoz` and add `@ru` attribute to appropriate domains. In the process I discovered that most (if not all) domains resolve to Russian IPs, so it only makes sense to include `ucoz` entirely in `category-ru`.

I also added a few new uCoz domains.