### PR TITLE
mailru-group: add .kz domains

### DIFF
--- a/data/mailru-group
+++ b/data/mailru-group
@@ -253,6 +253,10 @@ uma.media
 viqeo.tv
 viqeotv.com
 
+## VK Cloud KZ (joint venture with QazCloud)
+vkcloud-static.kz
+vkcloud.kz
+
 ## VK Play
 vkplay-arena.ru
 vkplay.ru

--- a/data/mailru-group
+++ b/data/mailru-group
@@ -12,6 +12,7 @@ hrtek.ru
 koddobra.ru
 lovina.app
 mail.ru
+mcs.st
 mediumquality.ru
 memealerts.com
 movika.com
@@ -24,6 +25,7 @@ vk-apps.ru
 vk-records.ru
 vk-stadium.ru
 vk.company
+vk.kz
 vk.team
 vkclips.app
 vkcs.cloud
@@ -31,6 +33,7 @@ vkfest.ru
 vkgo.app
 vklive.app
 vkvideo.ru
+vkworkspace.kz
 yclients.com
 
 # IDN ccTLD


### PR DESCRIPTION
Added VK Cloud KZ domains. VK Cloud KZ is a joint venture with QazCloud. Both resolve to AS201817 (VK Tech Kazakhstan LLP).

**UPD:** Also found some other non-ru domains used by VK that also resolve to AS201817. Source: VirusTotal passive DNS replication history.