### PR TITLE
hbo: add TLD hbo

### DIFF
--- a/data/hbo
+++ b/data/hbo
@@ -4,6 +4,7 @@ cinemax.com
 discomax.com
 elpionero.es
 forthethrone.com
+hbo
 hbo.ba
 hbo.bg
 hbo.com

--- a/data/hbo
+++ b/data/hbo
@@ -1,10 +1,12 @@
+# All .hbo domains
+hbo
+
 beforeigners.com
 brightline.tv
 cinemax.com
 discomax.com
 elpionero.es
 forthethrone.com
-hbo
 hbo.ba
 hbo.bg
 hbo.com


### PR DESCRIPTION
The .hbo domain extension is a branded top-level domain (TLD) that is exclusively used by Home Box Office, Inc., a popular American television and streaming service. This domain extension supports HBO's digital presence, both serving to enhance the brand's image and to facilitate secure interactions with users. Since it is a branded domain, it is not available for public registration, meaning only authorized HBO entities can register or use .hbo domains. HBO utilizes this domain for various purposes including marketing initiatives, service offerings, and other corporate-related activities.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

