### PR TITLE
add PayMe technical domain to HSBC

### DIFF
--- a/data/hsbc
+++ b/data/hsbc
@@ -62,3 +62,6 @@ hsbc.ca
 hsbc.co.jp
 hsbc.fr
 hsbctrinkaus.de
+
+# PayMe by HSBC
+vv1865.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Currently, when using PayMe, domains like payme-api-secure.hsbc.com are captured by the 'hsbc' ruleset, but pubpayme.prod.ap-east-1.pm4c.cloud1.vv1865.com is not. According to [Cloudflare Radar](https://radar.cloudflare.com/domains/domain/vv1865.com), the parent domain vv1865.com belongs to HSBC. Adding this parent domain to the 'hsbc' ruleset will fix the issue.