### PR TITLE
archlinux: add archlinux.page

### DIFF
--- a/data/archlinux
+++ b/data/archlinux
@@ -1,5 +1,6 @@
 archlinux.de
 archlinux.org
+archlinux.page
 archlinuxarm.org
 pkgbuild.com
 


### PR DESCRIPTION
Arch Linux RFCs are hosted on this domain, such as <https://rfc.archlinux.page/0023-pack-relative-relocs/>