### PR TITLE
geolocation-!cn: add zhangzhehan.net

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -339,3 +339,4 @@ include:xdty
 include:xingrz
 
 sinyalee.com
+zhangzhehan.net


### PR DESCRIPTION
Add geosite category for zhangzhehan.net

The website appears inaccessible from mainland China without proxy/VPN. Multiple users observed connectivity issues including DNS/TLS anomalies from mainland China networks, while the site remains accessible outside China.

Adding this domain may help users configure proxy routing rules more easily.


