### PR TITLE
category-netdisk-cn: add 123278.com (123pan)

### DIFF
--- a/data/category-netdisk-cn
+++ b/data/category-netdisk-cn
@@ -18,6 +18,7 @@ include:wenshushu
 123254.com
 123245.com
 123952.com
+123278.com
 
 cloud.189.cn # 天翼云盘
 ctfile.com # 城通网盘

--- a/data/category-netdisk-cn
+++ b/data/category-netdisk-cn
@@ -5,20 +5,20 @@ include:lanzou
 include:wenshushu
 
 # 123云盘
+123245.com
+123254.com
+123278.com
+123294.com
+123624.com
+123641.com
+123842.com
+123860.com
+123912.com
+123952.com
+123957.com
 123pan.cn
 123pan.com
 123panpay.com
-123957.com
-123912.com
-123860.com
-123842.com
-123641.com
-123624.com
-123294.com
-123254.com
-123245.com
-123952.com
-123278.com
 
 cloud.189.cn # 天翼云盘
 ctfile.com # 城通网盘


### PR DESCRIPTION
新增 123云盘的域名 123278.com

登录123云盘时，软件提示境外登陆风险，检查发现 api.123278.com 域名未包含 category-netdisk-cn 文件中，于是进行补充。