### PR TITLE
Add telemetry and ads domains to mozilla

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -30,6 +30,7 @@ include:meta @ads
 include:microsoft @ads
 include:mihoyo @ads
 include:mindbox @ads
+include:mozilla @ads
 include:mts-ru @ads
 include:netease @ads
 include:nicegram @ads

--- a/data/mozilla
+++ b/data/mozilla
@@ -17,6 +17,4 @@ thunderbird.net
 
 full:ads.mozilla.org @ads
 full:incoming.telemetry.mozilla.org @ads
-full:classify-client.services.mozilla.com @ads
-full:contile.services.mozilla.com @ads
 full:incoming-telemetry.thunderbird.net @ads

--- a/data/mozilla
+++ b/data/mozilla
@@ -15,6 +15,8 @@ mzl.la
 seamonkey-project.org
 thunderbird.net
 
+# Ads/tracking
+full:ads-img.mozilla.org @ads
 full:ads.mozilla.org @ads
 full:incoming.telemetry.mozilla.org @ads
 full:incoming-telemetry.thunderbird.net @ads

--- a/data/mozilla
+++ b/data/mozilla
@@ -14,3 +14,9 @@ mozillafoundation.org
 mzl.la
 seamonkey-project.org
 thunderbird.net
+
+full:ads.mozilla.org @ads
+full:incoming.telemetry.mozilla.org @ads
+full:classify-client.services.mozilla.com @ads
+full:contile.services.mozilla.com @ads
+full:incoming-telemetry.thunderbird.net @ads


### PR DESCRIPTION
1. Add Firefox and Thunderbird telemetry / tracking / ads domains in `mozilla` category:

`ads.mozilla.org`
`incoming.telemetry.mozilla.org`
`classify-client.services.mozilla.com`
`contile.services.mozilla.com`
`incoming-telemetry.thunderbird.net`

2. Add `mozilla` category to `category-ads`.

Source: https://support.mozilla.org/en-US/kb/domains-allow-firefox