### PR TITLE
Add Stripe to finance category includes

### DIFF
--- a/data/category-finance
+++ b/data/category-finance
@@ -14,6 +14,7 @@ include:longbridge
 include:n26
 include:schwab
 include:standardchartered
+include:stripe
 include:wise
 
 fxcorporate.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Or we need a new `category-payment-!cn` to selectively route payment processing websites to proxies with better IP quality?