### PR TITLE
mailru-group: add trace-flow.ru

### DIFF
--- a/data/mailru-group
+++ b/data/mailru-group
@@ -61,6 +61,7 @@ radar.imgsmail.ru @ads
 relap.mail.ru @ads
 target.my.com @ads
 top-fwz1.mail.ru @ads
+trace-flow.ru @ads
 tracker-api.my.com @ads
 tracker.my.com @ads
 full:1l-hit.mail.ru @ads


### PR DESCRIPTION
`trace-flow.ru` resolves to AS47764 (LLC VK) and is used in messenger MAX for tracking, namely to submit results of network analysis for censorship circumvention attempts.

Source: VT, [Habr](https://habr.com/en/articles/1036222/).