### PR TITLE
google-deepmind: add `gemini.gstatic.com`

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -21,6 +21,7 @@ aistudio.google.com
 bard.google.com
 gemini.google
 gemini.google.com
+gemini.gstatic.com
 
 # Gemini Code Assist
 # https://docs.cloud.google.com/gemini/docs/codeassist/set-up-gemini


### PR DESCRIPTION
when accessing Google Gemini (gemini.google.com), the service makes requests to gemini.gstatic.com 

the domain existence can be verified by running: `ping gemini.gstatic.com`