### PR TITLE
Add Scholar HK; Add trackers for Apple & Huawei; Optimize CMCC and add CMI relavant rules(CMHK, CMLink, jegotrip); Add @cn attr and multiple CN providers to connectivity-check; Add EE and H3G(3/Three/Hutch/WindTre)

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -994,3 +994,4 @@ api-adservices.apple.com @ads
 iadsdk.apple.com @ads
 iad.apple.com @ads
 qwapi.com @ads
+radarsubmissions.apple.com.akadns.net @ads

--- a/data/category-scholar-!cn
+++ b/data/category-scholar-!cn
@@ -1,6 +1,7 @@
 # This list contains scholarly domains that don't have access point in China Mainland.
 
 include:category-scholar-ir
+include:category-scholar-hk
 include:category-scholar-uk
 include:apa
 include:clarivate

--- a/data/category-scholar-hk
+++ b/data/category-scholar-hk
@@ -1,0 +1,18 @@
+# This list contains scholarly domains that in HK
+
+include:cityu-hk
+include:cuhk
+include:eduhk
+include:hkbu
+include:hku
+include:hkust
+include:polyu
+
+# https://www.hkdnr.hk/en/register/eligibility-required-documents/
+# https://www.jucc.edu.hk/shared-services-platforms/
+# https://www.edb.gov.hk/en/edu-system/postsecondary/local-higher-edu/institutions/index.html
+
+edu.hk
+
+# 教育.香港
+xn--wcvs22d.xn--j6w193g

--- a/data/category-voip
+++ b/data/category-voip
@@ -1,1 +1,2 @@
 include:talkatone
+include:jegotrip

--- a/data/chinamobile
+++ b/data/chinamobile
@@ -2,8 +2,7 @@
 139.com
 chinamobile.com
 chinamobileltd.com
-speedtest.hk.chinamobile.com @!cn
-speedtestbb.hk.chinamobile.com @!cn
+
 
 # Migu
 cmread.com

--- a/data/cityu-hk
+++ b/data/cityu-hk
@@ -7,6 +7,6 @@ regexp: ^cityu(\.edu)?\.hk$
 # 城大.香港
 xn--uis44a.xn--j6w193g
 
-https://www.whois.com/whois/cityu.edu.hk
+# https://www.whois.com/whois/cityu.edu.hk
 # 城市大學-香港.教育.香港 
 xn----fr0b94b15d2ue8q7a1o3e.xn--wcvs22d.xn--j6w193g

--- a/data/cityu-hk
+++ b/data/cityu-hk
@@ -1,0 +1,12 @@
+# City University of Hong Kong (CityU)
+# cityu.hk
+# cityu.edu.hk
+regexp: ^cityu(\.edu)?\.hk$
+
+# https://www.whois.com/whois/cityu.hk
+# 城大.香港
+xn--uis44a.xn--j6w193g
+
+https://www.whois.com/whois/cityu.edu.hk
+# 城市大學-香港.教育.香港 
+xn----fr0b94b15d2ue8q7a1o3e.xn--wcvs22d.xn--j6w193g

--- a/data/cmhk
+++ b/data/cmhk
@@ -1,2 +1,4 @@
 # China Mobile Hong Kong
 hk.chinamobile.com
+full:peo.prod.ondemandconnectivity.com
+mnc012.mcc454.pub.3gppnetwork.org

--- a/data/cmhk
+++ b/data/cmhk
@@ -1,0 +1,2 @@
+# China Mobile Hong Kong
+hk.chinamobile.com

--- a/data/cmi
+++ b/data/cmi
@@ -1,0 +1,5 @@
+# China Mobile International
+cmi.chinamobile.com
+include:jegotrip
+include:cmhk
+include:cmlink

--- a/data/cmlink
+++ b/data/cmlink
@@ -1,0 +1,2 @@
+# CMLink
+keyword:cmlink

--- a/data/cmlink
+++ b/data/cmlink
@@ -1,2 +1,5 @@
 # CMLink
+cmlink.com
 keyword:cmlink
+
+include:ee @uk

--- a/data/connectivity-check
+++ b/data/connectivity-check
@@ -1,5 +1,7 @@
+# Connectivity Check, default is used for checking global connectivity. use geosite:connectivity-check@cn for CHN network direct testing
+
 # Apple
-captive.apple.com
+captive.apple.com @cn # Apple captive portal default direct
 
 # Arch Linux
 full:ping.archlinux.org
@@ -14,20 +16,41 @@ network-test.debian.org
 # Firefox
 detectportal.firefox.com
 
+# GNOME
+nmcheck.gnome.org
+
 # Google
 connectivitycheck.gstatic.com
+www.gstatic.com
+www.google.com
 
 # Honor
-full:connectivitycheck.platform.hihonorcloud.com
+full:connectivitycheck.platform.hihonorcloud.com @cn
 
 # Huawei
-full:connectivitycheck.platform.hicloud.com
+full:connectivitycheck.platform.hicloud.com @cn
 
 # KDE
 networkcheck.kde.org
 
+# Kuketz.DE
+kuketz.de
+
+# MicroSoft Edge
+edge-http.microsoft.com
+
 # MIUI
-full:connect.rom.miui.com
+full:connect.rom.miui.com @cn
+
+# OPPO
+full:conn1.oppomobile.com @cn
+
+# Quadcolmm
+www.qualcomm.cn @cn
+www.qualcomm.com
+
+# Samsung
+connectivity.samsung.com.cn @cn
 
 # Steam
 ipv6check-http.steamserver.net
@@ -36,6 +59,9 @@ test.steampowered.com
 
 # Ubuntu
 full:connectivity-check.ubuntu.com
+
+# Vivo
+full:wifi.vivo.com.cn @cn
 
 # Windows
 msftconnecttest.com

--- a/data/ctexcel
+++ b/data/ctexcel
@@ -1,5 +1,10 @@
 ctexcel.ca @!cn
-ctexcel.com @!cn
+ctexcel.com @!cn @uk
 ctexcel.com.hk @!cn
 ctexcel.fr @!cn
 ctexcel.us @!cn
+
+chinatelecomhk.com @hk
+mnc031.mcc454.pub.3gppnetwork.org @hk
+
+include:ee @uk

--- a/data/cuhk
+++ b/data/cuhk
@@ -1,0 +1,6 @@
+# The Chinese University of Hong Kong (CUHK)
+regexp: ^cuhk(\.edu)?\.hk$
+# 中大.香港 / 中文大學.香港
+regexp: ^(xn--mxtq18a|xn--fiqs8s1byzqyvl)\.(hk|xn--j6w193g)$
+# 香港中文大學.香港
+regexp: ^xn--pssu7cv61ahwcb1p2yk\.(hk|xn--j6w193g)$

--- a/data/cuniq
+++ b/data/cuniq
@@ -1,0 +1,9 @@
+# CUniq 中国联通国际
+
+full:us.cuniq.com @us
+
+cuniq.com @hk
+
+cuniq.sg @sg
+
+cuniq.jp @jp

--- a/data/eduhk
+++ b/data/eduhk
@@ -1,0 +1,6 @@
+# The Education University of Hong Kong (EdUHK)
+regexp: ^eduhk(\.edu)?\.hk$
+# 教大.香港 / 教育大學.香港
+regexp: ^(xn--wcv22d|xn--wcvs22d1m)\.(hk|xn--j6w193g)$
+# 香港教育大學.香港
+regexp: ^xn--pssu7cv61af1tcs59bnvd\.(hk|xn--j6w193g)$

--- a/data/ee
+++ b/data/ee
@@ -1,0 +1,5 @@
+# Everything Everywhere, An UK ISP
+ee.co.uk
+mnc030.mcc234.pub.3gppnetwork.org
+mnc033.mcc234.pub.3gppnetwork.org
+mnc071.mcc234.pub.3gppnetwork.org

--- a/data/h3g
+++ b/data/h3g
@@ -1,0 +1,59 @@
+# Hutchinson/H3G 和記電訊
+
+three.com
+
+# eSIM Provisioning
+gsma-es9plus-in.production.odceu.nmcs.gcloud.thalescloud.io @esim
+
+# Three Hong Kong
+three.com.hk @hk
+hhk.prod.ondemandconnectivity.com @hk
+mnc088.mcc454.pub.3gppnetwork.org @hk
+
+# Three Macau
+three.com.mo @mo
+mnc003.mcc455.pub.3gppnetwork.org @mo
+mnc005.mcc455.pub.3gppnetwork.org @mo
+
+# Three United Kingdom
+three.co.uk @uk
+threemediacentre.co.uk @uk
+huk.prod.ondemandconnectivity.com @uk
+esim-es-open-prod-tuk.esimcloud.net @uk
+mnc020.mcc234.pub.3gppnetwork.org @uk
+mnc094.mcc234.pub.3gppnetwork.org @uk
+vodafonethree.com @uk
+
+# Three Ireland
+three.ie @ie
+mnc002.mcc272.pub.3gppnetwork.org @ie
+mnc005.mcc272.pub.3gppnetwork.org @ie
+
+# Three Austria
+drei.at @at
+mnc010.mcc232.pub.3gppnetwork.org @at
+
+# Three Indonesia
+tri.co.id @id
+mnc089.mcc510.pub.3gppnetwork.org @id
+
+# Hutch Sri Lanka
+hutch.lk @lk
+mnc008.mcc413.pub.3gppnetwork.org @lk
+
+# Three Denmark
+3.dk @dk
+mnc006.mcc238.pub.3gppnetwork.org @dk
+
+
+# Three Sweden
+tre.se @se
+mnc002.mcc242.pub.3gppnetwork.org @se
+
+# Wind Tre (Italy)
+windtre.it @it
+mnc037.mcc222.pub.3gppnetwork.org @se
+mnc088.mcc222.pub.3gppnetwork.org @se
+mnc099.mcc222.pub.3gppnetwork.org @se
+
+

--- a/data/hkbu
+++ b/data/hkbu
@@ -1,0 +1,6 @@
+# Hong Kong Baptist University (HKBU)
+regexp: ^hkbu(\.edu)?\.hk$
+# 浸大.香港 / 浸會大學.香港
+regexp: ^(xn--gdt08a|xn--fiqs8s1bxp3anr7a)\.(hk|xn--j6w193g)$
+# 香港浸會大學.香港
+regexp: ^xn--pssu7cv61ahw8aq79bztd\.(hk|xn--j6w193g)$

--- a/data/hkt
+++ b/data/hkt
@@ -10,3 +10,12 @@ hktshop.com
 netvigator.com
 theclub.com.hk
 uhub.com
+
+# Mobile 
+csl.prod.ondemandconnectivity.com
+mnc000.mcc454.pub.3gppnetwork.org
+mnc002.mcc454.pub.3gppnetwork.org
+mnc010.mcc454.pub.3gppnetwork.org
+mnc016.mcc454.pub.3gppnetwork.org
+mnc019.mcc454.pub.3gppnetwork.org
+mnc029.mcc454.pub.3gppnetwork.org

--- a/data/hku
+++ b/data/hku
@@ -1,0 +1,8 @@
+# The University of Hong Kong (HKU) 
+# hku.hk
+# hku.edu.hk
+regexp: ^hku(\.edu)?\.hk$
+
+# https://www.whois.com/whois/hku.hk
+# 香港大學.HK / .香港
+regexp: ^xn--pssu7cv61af44b\.(hk|xn--j6w193g)$

--- a/data/hkust
+++ b/data/hkust
@@ -1,0 +1,8 @@
+# The Hong Kong University of Science and Technology
+# hkust.hk
+# hkust.edu.hk
+regexp: ^hkust(\.edu)?\.hk$
+
+# https://www.whois.com/whois/hkust.hk
+# 香港科技大學.HK /.香港
+regexp: ^xn--pssu7ci2j23mp9ny48b\.(hk|xn--j6w193g)$

--- a/data/huawei
+++ b/data/huawei
@@ -8,7 +8,7 @@ dbankcdn.cn
 dbankcdn.com
 dbankcloud.cn
 dbankcloud.com
-dbankcloud.ru @!cn
+dbankcloud.ru 
 dbankedge.cn
 dbankedge.net
 hicloud.com
@@ -29,4 +29,16 @@ vmall.com
 vmallres.com
 
 # Tracking
-domain:dt.dbankcloud.ru @ads @!cn
+domain:dt.dbankcloud.ru @ads 
+domain:dt.dbankcloud.cn @ads 
+domain:logservice1.dbankcloud.cn @ads
+regexp: ^(.*-)?drcn\.((dt|op|cloud)\.)?dbank(.*)?\.(.*)$ @ads
+full: h5hosting-drcn.dbankcdn.cn @ads
+regexp: ^metrics?\.(data\.hicloud|dbankcloud)\.(com|cn)$
+regexp: ^logservice1?\.(data\.hicloud|dbankcloud)\.(com|cn)$ @ads
+keyword: ad.hicloud @ads
+as.hicloud.com @ads
+ads.hicloud.com @ads
+click.hicloud.com @ads
+stats.hicloud.com @ads
+log.hicloud.com @ads

--- a/data/jegotrip
+++ b/data/jegotrip
@@ -1,0 +1,2 @@
+# 无忧行
+keyword:jegotrip

--- a/data/jegotrip
+++ b/data/jegotrip
@@ -1,2 +1,3 @@
 # 无忧行
-keyword:jegotrip
+justalkcloud.com
+jegotrip.com.cn

--- a/data/polyu
+++ b/data/polyu
@@ -1,0 +1,13 @@
+# The Hong Kong Polytechnic University
+# polyu.hk
+# polyu.edu.hk
+# xxxx-polyu.edu.hk (such as cpce-polyu.edu.hk)
+regexp: ^((.+)*-)?polyu(\.edu)?.hk$
+
+# https://www.whois.com/whois/polyu.edu.hk
+# 理工大學.教育.香港(Bundled but not reachable)
+# xn--pssu7cgzco90b.xn--wcvs22d.xn--j6w193g
+
+# https://www.whois.com/whois/polyu.hk
+# 香港-理工大學.香港(Bundled but not reachable)
+# xn----5b1b34e6wdxz4al6hzt2e.xn--j6w193g


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

What does this PR includes:

- Scholar HK, with `.edu.hk`, `教育.香港` and `.教育.hk` domains included. Included CUHK, HKU, PolyU, HKUST, EDUHK and CityU(HK)
- Add more trackers domains to apple and huawei
- remove useless speedtest.hk.chinamobile.com domains for chinamobile, and add CMI relavant rules. 
- CMHK and CMLink added as standalone ISPs/ mobile operators.(Still WIP)
- Added `@cn` attributes and providers from Samsung CN, Quadcolmm CN, OPPO and VIVO.