### PR TITLE
category-ru: add nplus1.ru

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -86,6 +86,7 @@ srv-hub.org        # Website buider
 t1.cloud           # Russian cloud storage provider
 taxsee.com         # Taxi for business (self-employed drivers)
 yourgood.app       # CRM for small business
+nplus1.ru          # N+1, popular science magazine
 
 ## Ads and tracking
 adriver.ru @ads

--- a/data/category-ru
+++ b/data/category-ru
@@ -78,6 +78,7 @@ kinescopecdn.net   # Kinescope video hosting CDN
 litres.ru          # E-book and audiobook service
 meteoinfo.ru       # Hydrometeorological Center of Russia
 ngenix.net         # NGENIX is a Russian provider of acceleration and security services for public web resources
+nplus1.ru          # N+1, popular science magazine
 ognihome.com       # OGNI HOME resident portal
 pochta.ru          # Russian post
 ponyexpress.ru     # Courier delivery service
@@ -86,7 +87,6 @@ srv-hub.org        # Website buider
 t1.cloud           # Russian cloud storage provider
 taxsee.com         # Taxi for business (self-employed drivers)
 yourgood.app       # CRM for small business
-nplus1.ru          # N+1, popular science magazine
 
 ## Ads and tracking
 adriver.ru @ads


### PR DESCRIPTION
Added popular science magazine nplus1.ru to Russian services list.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

