### PR TITLE
Fix #3668: added languagetool.org and added list category-education

### DIFF
--- a/data/category-education
+++ b/data/category-education
@@ -1,0 +1,4 @@
+include:category-education-ir
+include:category-education-cn
+
+languagetool.org


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

