### PR TITLE
data/geolocation-cn：add domains for 杭州烨彬科技有限公司

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1748,3 +1748,6 @@ wanji.net.cn
 
 # 广州市雅望互联网服务有限公司
 gzyowin.com
+
+# 杭州烨彬科技有限公司 浙ICP备2024084590号
+yebinnet.com


### PR DESCRIPTION
While monitoring network traffic on my Mac, I noticed that `g-page-h1-yebinnet.gslb.yebinnet.com` was being routed through a proxy instead of going direct. After investigation:

- `yebinnet.com` appears to be a niche CDN provider suspected to have a partnership with Apple in mainland China
- `yebinnet.com` is registered with China's MIIT ICP filing system (filing number: 浙ICP备2024084590号)
- DNS resolution via [dns.google](https://dns.google) confirms all returned IPs are mainland China addresses:

| IP | Region |
|---|---|
| 123.6.13.99 | China, Henan, Zhengzhou - AS4837 CHINA UNICOM China169 Backbone |
| 112.92.61.5 | China, Guangdong, Shenzhen - AS17816 China Unicom IP network China169 Guangdong province |
| 42.123.107.47 | China, Guizhou, Guiyang - AS58519  Telecom/Tianyi Cloud Computing Data Center |
| 116.153.80.3 | China, Jiangxi, Nanchang - AS4837 CHINA UNICOM China169 Backbone |
| 101.71.164.194 | China, Zhejiang, Hangzhou - AS4837 CHINA UNICOM China169 Backbone |
| 113.96.142.28 | China, Guangdong, Shenzhen - AS4134 CHINANET BACKBONE |
| 218.92.226.2 | China, Jiangsu, Yancheng - AS4134 CHINANET BACKBONE |

Based on the above, `yebinnet.com` and its subdomains should be classified as mainland China domains and added to `geolocation-cn`.