### PR TITLE
Add mobile ads and analytics tracking domains

### DIFF
--- a/data/avito
+++ b/data/avito
@@ -1,2 +1,4 @@
 avito.ru
 avito.st
+
+full:stats.avito.ru @ads

--- a/data/category-ads
+++ b/data/category-ads
@@ -6,6 +6,7 @@ include:adobe @ads
 include:alibaba @ads
 include:amazon @ads
 include:apple @ads
+include:avito @ads
 include:baidu @ads
 include:bytedance @ads
 include:carrotquest @ads

--- a/data/category-ads
+++ b/data/category-ads
@@ -149,9 +149,6 @@ applvn.com
 # AppsFlyer
 appsflyersdk.com
 
-# AppTracer
-apptracer.ru
-
 # Caixin
 # regexp:^pinggai\d\.caixin\.com$
 full:pinggai0.caixin.com

--- a/data/category-ads
+++ b/data/category-ads
@@ -145,6 +145,12 @@ pbmp.ali213.net
 applovin.com
 applvn.com
 
+# AppsFlyer
+appsflyersdk.com
+
+# AppTracer
+apptracer.ru
+
 # Caixin
 # regexp:^pinggai\d\.caixin\.com$
 full:pinggai0.caixin.com
@@ -199,6 +205,9 @@ ad.unimhk.com
 
 # UCloud
 das-rpt-log.ucloud.cn
+
+# Vungle
+full:logs.ads.vungle.com
 
 # 数字精准广告
 telecome.cn

--- a/data/yandex
+++ b/data/yandex
@@ -128,6 +128,7 @@ full:clck.yandex.com @ads
 full:clck.yandex.net @ads
 full:clck.yango.com @ads
 full:informer.yandex.ru @ads
+full:log.strm.yandex.ru @ads
 full:mc.yandex.com @ads
 full:mc.yandex.net @ads
 full:mc.yango.com @ads


### PR DESCRIPTION
This adds several mobile ads / analytics / attribution domains observed in client traffic.

Added:
- AppsFlyer SDK attribution endpoint
- Vungle ads logging endpoint
- AppTracer SDK endpoint
- Avito stats endpoint
- Yandex STRM logging endpoint