### PR TITLE
Add claudemcpcontent.com to anthropic

### DIFF
--- a/data/anthropic
+++ b/data/anthropic
@@ -3,6 +3,7 @@ clau.de
 claude.ai
 claude.com
 claudemcpclient.com
+claudemcpcontent.com
 claudeusercontent.com
 
 # CDN


### PR DESCRIPTION
Add `claudemcpcontent.com` to the Anthropic domain list.

This domain is used by Claude MCP (Model Context Protocol) content delivery and should be included alongside the existing `claudemcpclient.com` entry.