### PR TITLE
Add oaistatsig.com to the openai data file

### DIFF
--- a/data/openai
+++ b/data/openai
@@ -3,6 +3,7 @@ chat.com
 chatgpt.com
 crixet.com
 oaistatic.com
+oaistatsig.com
 oaiusercontent.com
 openai.com
 sora.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

During ChatGPT login on my iPhone, I noticed domain `api.oaistatsig.com` was visited (by monitoring the network traffic in router)

```
time="Jun 06 11:01:58" level=info msg="192.168.1.19:52362 <-> chatgpt.com:443" dialer="日本实验性 IEPL 专线 1" dscp=0 ip="104.18.32.47:443" mac="90:ec:ea:a6:8f:16" network=tcp4 outbound="ai_available" pname= policy=min_moving_avg sniffed=chatgpt.com
time="Jun 06 11:01:59" level=info msg="192.168.1.19:61056 <-> 104.18.42.153:443" dialer="香港实验性 IEPL 专线 1" dscp=0 ip="104.18.42.153:443" mac="90:ec:ea:a6:8f:16" network=udp4 outbound=fast pid=0 pname= policy=min_moving_avg sniffed=api.oaistatsig.com
time="Jun 06 11:02:00" level=info msg="192.168.1.19:49927 <-> 172.64.145.103:443" dialer="香港实验性 IEPL 专线 1" dscp=0 ip="172.64.145.103:443" mac="90:ec:ea:a6:8f:16" network=udp4 outbound=fast pid=0 pname= policy=min_moving_avg sniffed=api.oaistatsig.com
time="Jun 06 11:02:00" level=info msg="192.168.1.19:52363 <-> api.oaistatsig.com:443" dialer="香港高级 IEPL 专线 3" dscp=0 ip="104.18.42.153:443" mac="90:ec:ea:a6:8f:16" network=tcp4 outbound=fast pname= policy=min_moving_avg sniffed=api.oaistatsig.com
time="Jun 06 11:02:05" level=info msg="192.168.1.19:52367 <-> cdn.auth0.com:443" dialer="日本实验性 IEPL 专线 1" dscp=0 ip="3.166.212.101:443" mac="90:ec:ea:a6:8f:16" network=tcp4 outbound="ai_available" pname= policy=min_moving_avg sniffed=cdn.auth0.com
```