### PR TITLE
Update unity: add missing tracking domains

### DIFF
--- a/data/unity
+++ b/data/unity
@@ -2,5 +2,7 @@ unity.com
 unity3d.com
 
 # Ads/tracking
+config.uca.cloud.unity3d.com @ads
+cdp.cloud.unity3d.com @ads
 iads.unity3d.com @ads
 unityads.unity3d.com @ads


### PR DESCRIPTION
### Description
This PR adds two missing Unity tracking/analytics domains to the `data/unity` file. 

**Added domains:**
* `config.uca.cloud.unity3d.com`
* `cdp.cloud.unity3d.com`

**Reason for change:**
These domains are actively used by Unity for cloud analytics, telemetry, and customer data collection (CDP). They have been placed under the `# Ads/tracking` section and properly tagged with the `@ads` attribute to ensure they can be categorized and routed correctly by users who wish to block tracking requests.