### PR TITLE
category-cas: remove verizon

### DIFF
--- a/data/category-cas
+++ b/data/category-cas
@@ -26,7 +26,6 @@ include:swisssign
 include:telekom
 include:trustwave
 include:twca
-include:verizon
 include:vodafone
 include:wisekey
 


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Update #1212