### PR TITLE
feat: add U-NEXT domains (Japanese streaming service)

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -69,6 +69,7 @@ include:tmdb
 include:tvdb
 include:tver
 include:twitch
+include:unext
 include:vimeo
 include:visualarts
 include:viu

--- a/data/unext
+++ b/data/unext
@@ -1,0 +1,4 @@
+nxtv.jp
+unext-info.jp
+unext.co.jp
+unext.jp


### PR DESCRIPTION
### Purpose
This PR adds the domain list for **U-NEXT**, a leading Japanese video streaming service, to the `data/` directory. This will allow users to route U-NEXT traffic to Japanese nodes (unlocking proxies) easily using `geosite:unext`.

### Changes
- Created a new file `data/unext` containing verified domains associated with U-NEXT.
- Sorted domains in alphabetical order.

### Verified Domains
- `nxtv.jp` (CDN and video distribution server)
- `unext-info.jp` (Official system & support notices)
- `unext.co.jp` (Corporate website)
- `unext.jp` (Main streaming portal)