### PR TITLE
google-deepmind: add waa-pa & people-pa under clients6.google.com

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -23,6 +23,14 @@ gemini.google
 gemini.google.com
 gemini.gstatic.com
 
+# Gemini shared private-API backends (gRPC over clients6.google.com)
+# waa-pa: Web Abuse Arbiter integrity tokens; required by gemini.google.com,
+#         aistudio.google.com and listed in Google's official Gemini firewall
+#         allowlist (https://support.google.com/a/answer/15627649).
+# people-pa: Internal People API, used by Gemini for account/profile context.
+full:waa-pa.clients6.google.com
+full:people-pa.clients6.google.com
+
 # Gemini Code Assist
 # https://docs.cloud.google.com/gemini/docs/codeassist/set-up-gemini
 full:cloudaicompanion.googleapis.com


### PR DESCRIPTION
### What
Add two `*-pa.clients6.google.com` subdomains that current Gemini frontends
(both `gemini.google.com` and `aistudio.google.com`) call but the existing
`google-deepmind` list does not match:

- `full:waa-pa.clients6.google.com`
- `full:people-pa.clients6.google.com`

### Why
`clients6.google.com` is Google's shared host for `-pa` (private API) gRPC
endpoints. Different products mount different `*-pa` subdomains under it. The
existing list only covers AI Studio's three `alkali*-pa` endpoints. Modern
Gemini frontends additionally call:

- **waa-pa.clients6.google.com** — *Web Abuse Arbiter*: the gRPC
  `google.internal.waa.v1.Waa/Create` integrity-token service. Without it,
  the Gemini web UI loads but message sends are blocked with region/abuse
  errors. This domain is explicitly listed in Google's own Gemini app
  firewall allowlist: https://support.google.com/a/answer/15627649
- **people-pa.clients6.google.com** — Google's *Internal People API*
  (distinct from the public `people.googleapis.com`). Used by Gemini for
  account/profile context and `@mention` features. Documented as
  "Internal People API" in
  https://github.com/google/google-api-javascript-client/issues/608

### Why `full:` (not a bare suffix)
PR #3292 proposes replacing the existing `full:alkali*` entries with a bare
`clients6.google.com` suffix. While simpler, that would also route
`*.clients6.google.com` subdomains used by Gmail, Drive, Photos,
Workspace add-ons, etc. — products that users may want on a different
outbound. Sticking with `full:` keeps the list narrowly scoped to Gemini's
known backends; new Gemini subdomains can be added one at a time as they
are observed in the wild.

### Verification
Captured live from a Gemini session: both subdomains appear in DevTools
network traffic and the Gemini "region not supported" errors reported in
issues #2378, #2938 and #3188 go away once these two are routed through the
same outbound as the rest of `google-deepmind`.

Refs: #2938, #2378, PR #3292