### PR TITLE
Add new analytics and performance tracking domains

### DIFF
--- a/data/unity
+++ b/data/unity
@@ -2,5 +2,13 @@ unity.com
 unity3d.com
 
 # Ads/tracking
+analytics.cloud.unity3d.com @ads
+api2.amplitude.com @ads
+config.uca.cloud.unity3d.com @ads
+cdp.cloud.unity3d.com @ads
+dashboard.unityads.unity3d.com @ads
+prd-lender.cdp.internal.unity3d.com @ads
 iads.unity3d.com @ads
+perf.cloud.unity3d.com @ads
+perf-events.cloud.unity3d.com @ads
 unityads.unity3d.com @ads

--- a/data/unity
+++ b/data/unity
@@ -2,11 +2,11 @@ unity.com
 unity3d.com
 
 # Ads/tracking
+# https://github.com/v2fly/domain-list-community/pull/3716
 analytics.cloud.unity3d.com @ads
 api2.amplitude.com @ads
 config.uca.cloud.unity3d.com @ads
 cdp.cloud.unity3d.com @ads
-dashboard.unityads.unity3d.com @ads
 prd-lender.cdp.internal.unity3d.com @ads
 iads.unity3d.com @ads
 perf.cloud.unity3d.com @ads


### PR DESCRIPTION
This is a resubmission and follow-up to my previously closed PR [#3692](https://github.com/v2fly/domain-list-community/pull/3692).

I sincerely apologize for the delayed response and for not providing the background information in time. I was quite busy over the past few days, and more importantly, to be responsible to the community, I spent some time testing these blocked domains on my own router to ensure that blocking them wouldn't cause any side effects or issues with the normal operation of Unity-related programs like Unity Editor or Unity Hub. After a few days of testing, I can confirm that there are absolutely no negative impacts.

These domains, which should be blocked due to ads, tracking, or telemetry, are derived directly from the **official Unity proxy exception list documentation**:
 [Defining exceptions on a Web proxy (Unity Official Manual)](https://docs.unity3d.com/Manual/ent-proxy-exception-list.html)

Below is the table summarizing the domains to be blocked and their exact purposes as described in the official documentation:

| Domain | Official Documentation Description / Actual Purpose |
| :--- | :--- |
| `analytics.cloud.unity3d.com` | Unity Hub analytics |
| `api2.amplitude.com` | Analytics for Unity Hub (via Amplitude third-party data service) |
| `config.uca.cloud.unity3d.com` | Opt-in to analytics state via remote configuration |
| `cdp.cloud.unity3d.com` | Common data platform used to collect data for analytics |
| `prd-lender.cdp.internal.unity3d.com` | Relaying data to Unity for internal analytics |
| `perf.cloud.unity3d.com` | Performance and crash reporting service |
| `perf-events.cloud.unity3d.com` | Performance event collection |
| `dashboard.unityads.unity3d.com` | Dashboard for ads and monetization |

I hope this explanation provides enough background context to support merging this PR. If there's any further information needed, please let me know and I will follow up promptly. 

Please note that I am fully aware that `domain-list-community` is just a generic list provider; I am merely helping to maintain the `Ads/tracking` category.