### PR TITLE
add nspk.ru domain to bank-ru

### DIFF
--- a/data/category-bank-ru
+++ b/data/category-bank-ru
@@ -88,6 +88,9 @@ credit-zenit.ru
 zenit-card.ru
 zenit.ru
 
+# NSPK (QR-code payments)
+nspk.ru
+
 # Other
 absolutbank.ru
 akbars.ru


### PR DESCRIPTION
nspk.ru is a domain for QR-payments in Russia (SBP)

All (literally) banks in Russia use this domain for SBP integration (which is main payment solution system in Russia)

