### PR TITLE
Update broker domains

### DIFF
--- a/data/futu
+++ b/data/futu
@@ -1,13 +1,22 @@
 # 富途证券
-futuesop.com @cn
+futu.cn
+futu.link
+futu5.com
+futuau.com
+futuesop.com
 futufin.com
 futuhk.com
+futuhk1.com
+futuhk2.com
 futuhkapp.com
 futuhn.com
 futuholdings.com
-futuniuniu.com @cn
-futunn.com @cn
-futustatic.com @cn
+futuniuniu.com
+futunn.com
+futuoa.com
+futusg.com
+futustatic.com
+fututrade.com
 
 # 富途 moomoo 证券
 moomoo.com

--- a/data/itiger
+++ b/data/itiger
@@ -3,3 +3,8 @@ itiger.com
 itigergrowth.com
 itigergrowtha.com
 itigerup.com
+laohu8.com
+skytigris.cn
+tigerbbs.cn
+tigerbbs.com
+xiaohu8.com

--- a/data/longbridge
+++ b/data/longbridge
@@ -1,9 +1,11 @@
 longbridge.cloud
+longbridge.cn
 longbridge.com
 longbridge.global
 longbridge.hk
 longbridge.sg
 longbridgeapp.com
+longbridgehk.com
 longportapp.com
 
 # Site Assets


### PR DESCRIPTION
- 更新部分券商的域名。
- 根据最新监管要求，使用中国大陆 IP 访问时无法入金和交易，因此删除富途证券的 `@cn` 标签。