### PR TITLE
Create regru

### DIFF
--- a/data/category-companies
+++ b/data/category-companies
@@ -84,6 +84,7 @@ include:qnap
 include:qualcomm
 include:qwant
 include:razer
+include:regru
 include:rostelecom
 include:salesforce
 include:samsung

--- a/data/category-ru
+++ b/data/category-ru
@@ -36,6 +36,7 @@ include:kontur
 include:mailru-group
 include:mindbox
 include:myoffice-ru
+include:regru
 include:selectel
 include:skyeng
 include:tilda

--- a/data/regru
+++ b/data/regru
@@ -1,0 +1,3 @@
+reg.cloud
+reg.com
+reg.ru


### PR DESCRIPTION
Added [REG.RU](https://www.reg.ru/company), a Russian domain registrar and hosting/cloud provider. This request includes core platform, international and cloud portal domains. It's also added to `category-companies` and `category-ru`.