### PR TITLE
Add saasexch.info to the Binance data file

### DIFF
--- a/data/binance
+++ b/data/binance
@@ -39,4 +39,5 @@ appsflayer.com
 saasexch.cc
 saasexch.co
 saasexch.com
+saasexch.info
 saasexch.io


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

### Reason
Without including this domain, the account is being limited to "Withdrawal Only" mode.

### Data source
Sniffed from the official Binance mobile app traffic via Xray core inbound logs.