### PR TITLE
Create nic-ru

### DIFF
--- a/data/category-companies
+++ b/data/category-companies
@@ -73,6 +73,7 @@ include:musixmatch
 include:mxroute
 include:naver
 include:neuralink
+include:nic-ru
 include:nvidia
 include:openweather
 include:oracle

--- a/data/category-ru
+++ b/data/category-ru
@@ -36,6 +36,7 @@ include:kontur
 include:mailru-group
 include:mindbox
 include:myoffice-ru
+include:nic-ru
 include:regru
 include:selectel
 include:skyeng

--- a/data/nic-ru
+++ b/data/nic-ru
@@ -1,0 +1,4 @@
+nichost.ru
+nic.ru
+r01.ru
+sweb.ru


### PR DESCRIPTION
Added [RU-CENTER](https://www.nic.ru/about), a Russian domain registrar and hosting provider. This request includes core brands: NIC.RU, R01, SpaceWeb and Nichost infrastructure domains. It's also added to `category-companies` and `category-ru`.