### PR TITLE
Add full:gist.github.com to github

### DIFF
--- a/data/github
+++ b/data/github
@@ -26,6 +26,7 @@ octocaptcha.com
 opensource.guide
 repo.new
 thegithubshop.com
+gist.github.com
 
 full:github-api.arkoselabs.com
 


### PR DESCRIPTION
### Description
Add `full:gist.github.com` explicitly to the `github` domain list.

### Reason
While `github.com` generally covers subdomains via suffix matching in some environments, certain strict downstream routing applications and compiled binary rule-sets (such as strict Radix-tree based compilers) fail to correctly route or generate nodes for `gist.github.com` when it's not explicitly declared. 

Since Gist is a core and essential service of the GitHub platform, adding it explicitly as a `full:` domain acts as a necessary high-precision patch. This ensures robust routing and consistent network policy enforcement without introducing generic subdomain redundancy.

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

