### PR TITLE
Update GOG

### DIFF
--- a/data/gog
+++ b/data/gog
@@ -2,15 +2,3 @@ gog.com
 gog-statics.com
 
 full:gog.qtlglb.com @cn
-full:gogalaxy.gog-statics.com @cn
-full:menu-static.gog-statics.com @cn
-full:productcard.gog-statics.com @cn
-full:static-login.gog-statics.com @cn
-full:www4-static.gog-statics.com @cn
-regexp:^cdn-akamai-.+\.gog-services\.com$ @cn
-regexp:^gog-cdn-.+\.footprint\.net$ @cn
-regexp:^images(-\d)?\.gog-statics\.com$ @cn
-
-# CDN available in China mainland
-full:gog-cdn-fastly.gog.com @cn
-full:gog-cdn.akamaized.net @cn

--- a/data/gog
+++ b/data/gog
@@ -2,3 +2,5 @@ gog.com
 gog-statics.com
 
 full:gog.qtlglb.com @cn
+full:gog-cdn-lumen.secure2.footprint.net
+full:gog-cdn.akamaized.net


### PR DESCRIPTION
Based on my own environment and DNS lookups via `chinaz.com` ([link](https://tool.chinaz.com/dns)), the IP addresses for these websites do not appear to be located in mainland China; they are primarily hosted on Fastly and Akamai servers.

They were introduced in the following commits or PRs:

- 559e60ece1f24609ce5df44521f1df420cd6d145
- #691
- #1033
- #2559

cc @Robot-DaneelOlivaw @Heptazhou @yueisme