### PR TITLE
Update GOG

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -16,6 +16,7 @@ include:disney @ads
 include:dmm @ads
 include:duolingo @ads
 include:gamersky @ads
+include:gog @ads
 include:google @ads
 include:hetzner @ads
 include:huawei @ads

--- a/data/gog
+++ b/data/gog
@@ -1,6 +1,12 @@
 gog.com
+gog-services.com
 gog-statics.com
+gogalaxy.com
 
 full:gog.qtlglb.com @cn
 full:gog-cdn-lumen.secure2.footprint.net
 full:gog-cdn.akamaized.net
+
+# Ads/tracking
+## https://www.gog.com/forum/general/telemetry_in_gog_galaxy_20/page1
+insights-collector.gog.com @ads


### PR DESCRIPTION
- `gog-services.com` itself does not resolve, but it includes subdomains such as `cdn-akamai-ec.gog-services.com`.
- `insights-collector.gog.com` is covered by this EasyPrivacy filter: `://insights-collector.`.