### PR TITLE
Add qweatherapi.com to qweather

### DIFF
--- a/data/qweather
+++ b/data/qweather
@@ -2,3 +2,4 @@ hecdn.net
 heweather.net
 qweather.com
 qweather.net
+qweatherapi.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Add `qweatherapi.com` to the `qweather` list.

According to QWeather's official documentation ([API Host](https://dev.qweather.com/docs/configuration/api-host/)), `qweatherapi.com` is the new dedicated API Host domain assigned to each developer, with the form `abc1234xyz.def.qweatherapi.com`.

The legacy public API addresses (`api.qweather.com`, `devapi.qweather.com`, `geoapi.qweather.com`) will be gradually deprecated starting from 2026 ([announcement](https://blog.qweather.com/announce/public-api-domain-change-to-api-host/)), so `qweatherapi.com` will become the primary domain for QWeather API traffic.