### PR TITLE
Add a copule of russian domains

### DIFF
--- a/data/category-ru
+++ b/data/category-ru
@@ -37,16 +37,16 @@ include:mailru-group
 include:mindbox
 include:myoffice-ru
 include:nic-ru
+include:positive-technologies
 include:regru
 include:selectel
+include:servicepipe
 include:skyeng
 include:tilda
 include:timeweb
 include:ucoz
 include:whoosh
 include:yandex
-include:servicepipe
-include:positive-technologies
 
 # Bank & Finance & Insurance & Securities
 include:category-bank-ru

--- a/data/category-ru
+++ b/data/category-ru
@@ -45,6 +45,7 @@ include:timeweb
 include:ucoz
 include:whoosh
 include:yandex
+include:servicepipe
 
 # Bank & Finance & Insurance & Securities
 include:category-bank-ru
@@ -97,6 +98,8 @@ srv-hub.org        # Website buider
 t1.cloud           # Russian cloud storage provider
 taxsee.com         # Taxi for business (self-employed drivers)
 yourgood.app       # CRM for small business
+randomgodbot.com   # Telegram randomizer bot
+foto-planeta.com   # Photo encyclopedia of settlements
 
 ## Ads and tracking
 adriver.ru @ads

--- a/data/category-ru
+++ b/data/category-ru
@@ -85,6 +85,7 @@ dom.ru
 3ebra.net          # Zebra Net Bureau, web development agency
 apptrackpets.com   # Pet GPS tracker service (Yandex Cloud, reg.ru)
 flomni.com         # Omnichannel communications platform
+foto-planeta.com   # Photo encyclopedia of settlements
 gazfond-pn.ru      # Non-state pension fund GAZFOND pension savings
 kinescopecdn.net   # Kinescope video hosting CDN
 litres.ru          # E-book and audiobook service
@@ -95,12 +96,11 @@ ognihome.com       # OGNI HOME resident portal
 pochta.ru          # Russian post
 ponyexpress.ru     # Courier delivery service
 qms.ru             # Russian internet speed testing service
+randomgodbot.com   # Telegram randomizer bot
 srv-hub.org        # Website buider
 t1.cloud           # Russian cloud storage provider
 taxsee.com         # Taxi for business (self-employed drivers)
 yourgood.app       # CRM for small business
-randomgodbot.com   # Telegram randomizer bot
-foto-planeta.com   # Photo encyclopedia of settlements
 
 ## Ads and tracking
 adriver.ru @ads

--- a/data/category-ru
+++ b/data/category-ru
@@ -46,6 +46,7 @@ include:ucoz
 include:whoosh
 include:yandex
 include:servicepipe
+include:positive-technologies
 
 # Bank & Finance & Insurance & Securities
 include:category-bank-ru

--- a/data/positive-technologies
+++ b/data/positive-technologies
@@ -1,3 +1,3 @@
-ptsecurity.com
 ptcloud.ru
+ptsecurity.com
 standoff365.com

--- a/data/positive-technologies
+++ b/data/positive-technologies
@@ -1,0 +1,3 @@
+ptsecurity.com
+ptcloud.ru
+standoff365.com

--- a/data/servicepipe
+++ b/data/servicepipe
@@ -1,0 +1,3 @@
+# Digital Fraud Protection
+servicepipe.tech
+servicepipe.ru

--- a/data/whoosh
+++ b/data/whoosh
@@ -1,2 +1,3 @@
 whoosh-bike.ru
 whoosh.bike
+whoosh

--- a/data/whoosh
+++ b/data/whoosh
@@ -1,3 +1,2 @@
 whoosh-bike.ru
 whoosh.bike
-whoosh


### PR DESCRIPTION
This PR adds domains for the following services:

+ Positive Technology ( A cybersecurity company)
+ TLD for Whoosh (Electric scooter renting app in Russia and Belarus)
+ Servicepipe (Fraud detection platform)
+ randomgodbot.com   (A randomizer mini-app in Telegram)
+ foto-planeta.com (Photo encyclopedia of settlements, mainly in Eastern Europe)

All of the above services are often not accessible from VPN/VPS IP ranges, so a rule is necessary for routing them directly