### PR TITLE
Add jsj.top into jinshuju

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1295,7 +1295,6 @@ jkbl.com
 job5588.com
 job910.com
 jobjm.com
-jsj.top # 陕ICP备19008575号-13
 jsrdgg.com
 jsyks.com
 juefeng.com

--- a/data/jinshuju
+++ b/data/jinshuju
@@ -1,2 +1,3 @@
 jinshuju.net
 jinshujucdn.com
+jsj.top


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

`jsj.top` is used to redirect to jinshuju.net, which is included in jinshuju category

```
C:\Users\user>curl -I https://jsj.top
HTTP/1.1 200 Connection established

HTTP/1.1 302 Moved Temporarily
Server: awselb/2.0
Date: Thu, 02 Jul 2026 03:43:19 GMT
Content-Type: text/html
Content-Length: 110
Connection: keep-alive
Location: https://jinshuju.net:443/
```
