### PR TITLE
openai: add openai.qualtrics.com and openaiassets.blob.core.windows.net

### DIFF
--- a/data/openai
+++ b/data/openai
@@ -11,6 +11,7 @@ sora.com
 # CDN & API
 openai.com.cdn.cloudflare.net
 full:openaiapi-site.azureedge.net
+full:openaiassets.blob.core.windows.net
 full:openaicom-api-bdcpf8c6d2e9atf6.z01.azurefd.net
 full:openaicom.imgix.net
 full:openaicomproductionae4b.blob.core.windows.net
@@ -18,8 +19,9 @@ full:production-openaicom-storage.azureedge.net
 regexp:^chatgpt-async-webps-prod-\S+-\d+\.webpubsub\.azure\.com$
 
 # tracking
-full:o33249.ingest.sentry.io @ads
 full:browser-intake-datadoghq.com @ads
+full:o33249.ingest.sentry.io @ads
+full:openai.qualtrics.com @ads
 
 # Advanced Voice
 chatgpt.livekit.cloud


### PR DESCRIPTION
Add openai.qualtrics.com (feedback/telemetry tracker) and openaiassets.blob.core.windows.net (CDN/assets storage) to the openai rules list, and sort the tracking section alphabetically.