### PR TITLE
Add Russian AI services, Flowwow, and Funpay

### DIFF
--- a/data/category-ai-ru
+++ b/data/category-ai-ru
@@ -1,0 +1,31 @@
+# Aiesa (AI assistant)
+aiesa.ru
+
+# Yandex Alice
+alice.yandex.net
+alice.yandex.ru
+alicepro.yandex.ru
+
+# CopyMonkey (AI copywriter)
+copymonkey.app
+
+# Gerwin (AI copywriter)
+gerwin.io
+
+# Sberbank GigaChat
+giga.chat
+
+# GPTunnel (LLM aggregator)
+gptunnel.ru
+
+# Polza (LLM aggregator)
+polza.ai
+
+# RoboText (AI text generator)
+robotext.io
+
+# RuGPT (AI text generator)
+rugpt.io
+
+# Tokenator (LLM aggregator)
+tokenator.top

--- a/data/category-ai-ru
+++ b/data/category-ai-ru
@@ -2,9 +2,9 @@
 aiesa.ru
 
 # Yandex Alice
-alice.yandex.net
-alice.yandex.ru
-alicepro.yandex.ru
+full:alice.yandex.net
+full:alice.yandex.ru
+full:alicepro.yandex.ru
 
 # CopyMonkey (AI copywriter)
 copymonkey.app

--- a/data/category-ai-ru
+++ b/data/category-ai-ru
@@ -2,9 +2,9 @@
 aiesa.ru
 
 # Yandex Alice
-full:alice.yandex.net
-full:alice.yandex.ru
-full:alicepro.yandex.ru
+alice.yandex.net
+alice.yandex.ru
+alicepro.yandex.ru
 
 # CopyMonkey (AI copywriter)
 copymonkey.app

--- a/data/category-ecommerce-ru
+++ b/data/category-ecommerce-ru
@@ -1,3 +1,5 @@
 include:avito
+include:flowwow
+include:funpay
 include:ozon
 include:wildberries

--- a/data/category-ru
+++ b/data/category-ru
@@ -8,6 +8,7 @@ ru.net
 # - You can still add `*.ru` domains here if you want
 
 # Subcategories
+include:category-ai-ru
 include:category-betting-ru
 include:category-ecommerce-ru
 include:category-entertainment-ru

--- a/data/flowwow
+++ b/data/flowwow
@@ -1,0 +1,2 @@
+flowwow-images.com
+flowwow.com

--- a/data/funpay
+++ b/data/funpay
@@ -1,0 +1,3 @@
+funpay.com
+funpay.ru
+sfunpay.com

--- a/data/tilda
+++ b/data/tilda
@@ -3,3 +3,4 @@ tilda.ru
 tilda.ws
 tildaapi.com
 tildacdn.com
+tildacdn.net


### PR DESCRIPTION
This PR introduces the following changes:
- Adds a new `category-ai-ru` containing popular Russian AI and LLM services (including GigaChat, Yandex Alice subdomains, Polza.ai, Tokenator, GPTunnel, Gerwin, and others).
- Includes the new `category-ai-ru` under `category-ru` subcategories.
- Adds `flowwow` and `funpay` to `category-ecommerce-ru`.
- Fixes `tilda` list formatting and adds `tildacdn.net`.

All domains are sorted alphabetically and files are formatted with a trailing newline according to the repository guidelines.
