### PR TITLE
Create pawchive

### DIFF
--- a/data/category-porn
+++ b/data/category-porn
@@ -48,6 +48,7 @@ include:missav
 include:moxing
 include:netflav
 include:nudevista
+include:pawchive
 include:picacg
 include:playboy
 include:pornhub

--- a/data/pawchive
+++ b/data/pawchive
@@ -1,0 +1,2 @@
+pawchive.pw
+pawchive.st


### PR DESCRIPTION
The website [Pawchive ](https://pawchive.pw) has been added.
It is an alternative to [Kemono](https://github.com/v2fly/domain-list-community/blob/master/data/kemono) (public archiver), which has already been added.