### PR TITLE
Update & sort apple-related categories

### DIFF
--- a/data/apple
+++ b/data/apple
@@ -772,7 +772,7 @@ full:km.support.apple.com @cn
 full:maps.apple.com @cn
 full:musicstatus.music.apple.com @cn
 full:play.music.apple.com @cn
-full:podcasts.apple.com
+full:podcasts.apple.com @cn
 full:speedysub.music.apple.com @cn
 full:www.support.apple.com @cn
 

--- a/data/apple
+++ b/data/apple
@@ -1,4 +1,4 @@
-include:apple-dev # swift inside
+include:apple-dev
 # Not include:apple-intelligence
 include:apple-music
 include:apple-pki
@@ -458,11 +458,18 @@ macbooksale.com
 wwwmacbookair.com
 
 # macOS
+apple-darwin.com
+apple-darwin.net
+apple-darwin.org
 appledarwin.com
 appledarwin.net
 darwinsource.com
 darwinsource.org
 darwinsourcecode.com
+macos.com.au
+macossierra.com
+macosx.info
+macosxlion.com
 
 # Shazam
 shazam.com
@@ -490,9 +497,6 @@ appl-e.com
 appl.com
 appl4e.com
 appla.com
-apple-darwin.com
-apple-darwin.net
-apple-darwin.org
 apple-dns.cn @cn
 apple-dns.com
 apple-dns.com.cn @cn
@@ -679,10 +683,6 @@ machos.net
 macintosh.eu
 macintoshsoftware.com
 macmini.com
-macos.com.au
-macossierra.com
-macosx.info
-macosxlion.com
 macpazar.com
 macreach.com
 macreach.net
@@ -811,10 +811,9 @@ full:s5.mzstatic.com @cn
 
 # The rules below are from https://github.com/felixonmars/dnsmasq-china-list/blob/master/apple.china.conf
 # Revision: c3c9839e5e71f04fc170b5645d7a162631985e2d
-# Duplicates removed
+# Duplicates removed; some domains were added to dedicated lists like itunes/apple-music
 # According to the consensus in #503, do not include the domain name apps.apple.com directly.
 # Use in config file like this: "geosite:apple@cn"
-# full:music.apple.com @cn has been moved to apple-music
 full:adcdownload.apple.com @cn
 full:adcdownload.apple.com.akadns.net @cn
 full:amp-api-updates.apps.apple.com @cn

--- a/data/apple
+++ b/data/apple
@@ -104,6 +104,105 @@ apple.xn--czr694b # apple.商标
 apple.xn--fiqs8s # apple.中国
 apple.xyz
 
+# App Store
+app-store.wang
+appe-store.com
+apple-appstore.cn @cn
+appleappstore.cn @cn
+appleappstore.net
+appleappstore.tv
+appsto.re
+appstore.co.id
+appstore.hk
+appstore.my
+appstore.ph
+appstoreapple.cn @cn
+asto.re
+tvappstore.net
+
+# Apple Care
+applecare.berlin
+applecare.cc
+applecare.eu
+applecare.hamburg
+applecare.wang
+
+# Apple ID
+appleaccount.net
+appleid-applemx.com
+appleid-applemx.us
+appleid-iclou.com
+appleid-uk.us
+appleid.berlin
+appleid.com
+appleid.hamburg
+appleid.hk
+ids-apple.com
+myappleid.com
+
+# Apple Music
+applemusic.berlin
+applemusic.co
+applemusic.com
+applemusic.com.au
+applemusic.hamburg
+applemusic.wang
+applemusicconnect.com
+applemusicfestival.com
+musickit.net
+wwwapplemusic.com
+
+# Apple News
+apple.comscoreresearch.com
+apple.news
+appleenews.com
+applenews.berlin
+applenews.hamburg
+applenews.tv
+applenewsformat.com
+
+# Apple One
+appleone.audio
+appleone.blog
+appleone.chat
+appleone.cloud
+appleone.club
+appleone.community
+appleone.film
+appleone.guide
+appleone.host
+appleone.space
+appleone.tech
+appleone.website
+
+# Apple Pay
+apple-pay.com
+apple-pay.rs
+apple-pay.wang
+applepay.berlin
+applepay.co.rs
+applepay.com.tw
+applepay.hamburg
+applepay.hk
+applepay.info
+applepay.jp
+applepay.rs
+applepay.tv
+applepaycash.cn @cn
+applepaycash.com.cn @cn
+applepaycash.net
+applepaycash.tv
+applepaymerchantsupplies.info
+applepaysupplies.berlin
+applepaysupplies.cn @cn
+applepaysupplies.com
+applepaysupplies.com.cn @cn
+applepaysupplies.info
+applepaysupplies.net
+applepaysupplies.tv
+applewallet.com
+applewallet.tv
+
 # Apple Store
 aplestore.com
 apple-store.cn @cn
@@ -151,21 +250,33 @@ applestoreonline.com
 applestorepro.eu
 onlineapplestore.com
 
-# App Store
-app-store.wang
-appe-store.com
-apple-appstore.cn @cn
-appleappstore.cn @cn
-appleappstore.net
-appleappstore.tv
-appsto.re
-appstore.co.id
-appstore.hk
-appstore.my
-appstore.ph
-appstoreapple.cn @cn
-asto.re
-tvappstore.net
+# Apple TV
+appletv.com
+appletv.fr
+appletv.wang
+appletv4.cn @cn
+appletv4.com.cn @cn
+appletvapp.apple
+
+# Apple Watch
+apple-watch.com.ru
+applewatch.hk
+applewatch.tv
+applewatch.tw
+applewatch.wang
+applewatchedition.com
+applewatchseries3.net
+applewatchsport.com
+
+# iBook
+i-book.com
+i-book.net
+ibook.co.nz
+ibook.com
+ibook.eu
+ibook.net
+ibookpartner.com
+ibooksauthor.com
 
 # iMac
 apple-imac.com
@@ -181,6 +292,11 @@ imac.one
 imac.rs
 imacapple.com
 imacapplecomputer.com
+
+# iMovie
+imovie.eu
+imoviegallery.com
+imoviestage.com
 
 # iPad
 ebookforipad.com
@@ -207,6 +323,54 @@ ipadmini.com.lk
 ipadmini.lk
 ipadpro.buzz
 ukipad.com
+
+# iPod
+aplleipods.com
+appleclassicipod.com
+downloadsforipod.com
+ipod.ca
+ipod.ch
+ipod.cm
+ipod.co
+ipod.co.nz
+ipod.co.uk
+ipod.co.za
+ipod.com
+ipod.com.au
+ipod.com.cn @cn
+ipod.com.fr
+ipod.com.hk
+ipod.com.sg
+ipod.com.tw
+ipod.de
+ipod.es
+ipod.eu
+ipod.fr
+ipod.gr
+ipod.hk
+ipod.is
+ipod.net
+ipod.no
+ipod.pk
+ipod.rs
+ipod.ru
+ipod.tw
+ipodcentre.nl
+ipodcleaner.com
+ipoditouch.com
+ipodnano.com
+ipodnano.net
+ipodprices.com
+ipodrip.ca
+ipodrocks.com.au
+ipods.com
+ipodshop.com.au
+ipodtouch.co
+ipodtouch.com
+myipod.net
+offrezdesipods.com
+simplyipod.com
+wwwipodlounge.com
 
 # iPhone
 appleiphone.hu
@@ -268,53 +432,11 @@ iphoneunlockimei.com
 iphonexs.tv
 onlyiphone5case.com
 
-# iPod
-aplleipods.com
-appleclassicipod.com
-downloadsforipod.com
-ipod.ca
-ipod.ch
-ipod.cm
-ipod.co
-ipod.co.nz
-ipod.co.uk
-ipod.co.za
-ipod.com
-ipod.com.au
-ipod.com.cn @cn
-ipod.com.fr
-ipod.com.hk
-ipod.com.sg
-ipod.com.tw
-ipod.de
-ipod.es
-ipod.eu
-ipod.fr
-ipod.gr
-ipod.hk
-ipod.is
-ipod.net
-ipod.no
-ipod.pk
-ipod.rs
-ipod.ru
-ipod.tw
-ipodcentre.nl
-ipodcleaner.com
-ipoditouch.com
-ipodnano.com
-ipodnano.net
-ipodprices.com
-ipodrip.ca
-ipodrocks.com.au
-ipods.com
-ipodshop.com.au
-ipodtouch.co
-ipodtouch.com
-myipod.net
-offrezdesipods.com
-simplyipod.com
-wwwipodlounge.com
+# iPhoto
+iphoto.eu
+iphoto.no
+iphoto.se
+iphoto.wang
 
 # MacBook
 imacsources.com
@@ -345,134 +467,12 @@ macbookpros.com
 macbooksale.com
 wwwmacbookair.com
 
-# Apple Watch
-apple-watch.com.ru
-applewatch.hk
-applewatch.tv
-applewatch.tw
-applewatch.wang
-applewatchedition.com
-applewatchseries3.net
-applewatchsport.com
-
-# Apple Music
-applemusic.berlin
-applemusic.co
-applemusic.com
-applemusic.com.au
-applemusic.hamburg
-applemusic.wang
-applemusicconnect.com
-applemusicfestival.com
-musickit.net
-wwwapplemusic.com
-
-# Apple News
-apple.comscoreresearch.com
-apple.news
-appleenews.com
-applenews.berlin
-applenews.hamburg
-applenews.tv
-applenewsformat.com
-
-# Apple Pay
-apple-pay.com
-apple-pay.rs
-apple-pay.wang
-applepay.berlin
-applepay.co.rs
-applepay.com.tw
-applepay.hamburg
-applepay.hk
-applepay.info
-applepay.jp
-applepay.rs
-applepay.tv
-applepaycash.cn @cn
-applepaycash.com.cn @cn
-applepaycash.net
-applepaycash.tv
-applepaymerchantsupplies.info
-applepaysupplies.berlin
-applepaysupplies.cn @cn
-applepaysupplies.com
-applepaysupplies.com.cn @cn
-applepaysupplies.info
-applepaysupplies.net
-applepaysupplies.tv
-applewallet.com
-applewallet.tv
-
-# iBook
-i-book.com
-i-book.net
-ibook.co.nz
-ibook.com
-ibook.eu
-ibook.net
-ibookpartner.com
-ibooksauthor.com
-
-# iPhoto
-iphoto.eu
-iphoto.no
-iphoto.se
-iphoto.wang
-
-# iMovie
-imovie.eu
-imoviegallery.com
-imoviestage.com
-
-# Apple Care
-applecare.berlin
-applecare.cc
-applecare.eu
-applecare.hamburg
-applecare.wang
-
 # macOS
 appledarwin.com
 appledarwin.net
 darwinsource.com
 darwinsource.org
 darwinsourcecode.com
-
-# Apple ID
-appleaccount.net
-appleid-applemx.com
-appleid-applemx.us
-appleid-iclou.com
-appleid-uk.us
-appleid.berlin
-appleid.com
-appleid.hamburg
-appleid.hk
-ids-apple.com
-myappleid.com
-
-# Apple TV
-appletv.com
-appletv.fr
-appletv.wang
-appletv4.cn @cn
-appletv4.com.cn @cn
-appletvapp.apple
-
-# Apple One
-appleone.audio
-appleone.blog
-appleone.chat
-appleone.cloud
-appleone.club
-appleone.community
-appleone.film
-appleone.guide
-appleone.host
-appleone.space
-appleone.tech
-appleone.website
 
 # Shazam
 shazam.com
@@ -756,6 +756,7 @@ full:amp-api-edge.music.apple.com @cn
 full:amp-api-search-edge.apps.apple.com @cn
 full:amp-api.apps.apple.com @cn
 full:amp-api.music.apple.com @cn
+full:amp-api.podcasts.apple.com @cn
 full:api-edge.apps.apple.com @cn
 full:auth.music.apple.com @cn
 full:communities.apple.com @cn
@@ -771,6 +772,7 @@ full:km.support.apple.com @cn
 full:maps.apple.com @cn
 full:musicstatus.music.apple.com @cn
 full:play.music.apple.com @cn
+full:podcasts.apple.com
 full:speedysub.music.apple.com @cn
 full:www.support.apple.com @cn
 

--- a/data/apple
+++ b/data/apple
@@ -1,6 +1,8 @@
 include:apple-dev # swift inside
 # Not include:apple-intelligence
+include:apple-music
 include:apple-pki
+include:apple-podcasts
 include:apple-tvplus
 include:apple-update
 include:beats
@@ -139,18 +141,6 @@ appleid.hamburg
 appleid.hk
 ids-apple.com
 myappleid.com
-
-# Apple Music
-applemusic.berlin
-applemusic.co
-applemusic.com
-applemusic.com.au
-applemusic.hamburg
-applemusic.wang
-applemusicconnect.com
-applemusicfestival.com
-musickit.net
-wwwapplemusic.com
 
 # Apple News
 apple.comscoreresearch.com
@@ -572,7 +562,6 @@ appleonline.net
 appleoriginalproductions.com
 appleos.tv
 applepencil.net
-applepodcasts.com
 applepremiumreseller.com.au
 applepremiumresellers.com.au
 applereach.com
@@ -752,13 +741,9 @@ courier-push-apple.com.akadns.net
 # Domains and services below are available in China mainland
 # Use in config file like this: "geosite:apple@cn"
 full:amp-api-edge.apps.apple.com @cn
-full:amp-api-edge.music.apple.com @cn
 full:amp-api-search-edge.apps.apple.com @cn
 full:amp-api.apps.apple.com @cn
-full:amp-api.music.apple.com @cn
-full:amp-api.podcasts.apple.com @cn
 full:api-edge.apps.apple.com @cn
-full:auth.music.apple.com @cn
 full:communities.apple.com @cn
 full:discussionschinese.apple.com @cn
 full:fides-pol.apple.com @cn
@@ -767,13 +752,8 @@ full:gspe12-cn-ssl.ls.apple.com @cn
 full:gspe85-cn-ssl.ls.apple.com @cn
 full:init.gc-lb.apple.com.akadns.net @cn
 full:init.gc.apple.com @cn
-full:js-cdn.music.apple.com @cn
 full:km.support.apple.com @cn
 full:maps.apple.com @cn
-full:musicstatus.music.apple.com @cn
-full:play.music.apple.com @cn
-full:podcasts.apple.com @cn
-full:speedysub.music.apple.com @cn
 full:www.support.apple.com @cn
 
 # regexp:^a[1-5]\.mzstatic\.com$ @cn
@@ -834,6 +814,7 @@ full:s5.mzstatic.com @cn
 # Duplicates removed
 # According to the consensus in #503, do not include the domain name apps.apple.com directly.
 # Use in config file like this: "geosite:apple@cn"
+# full:music.apple.com @cn has been moved to apple-music
 full:adcdownload.apple.com @cn
 full:adcdownload.apple.com.akadns.net @cn
 full:amp-api-updates.apps.apple.com @cn
@@ -901,7 +882,6 @@ full:mesu-cdn.apple.com.akadns.net @cn
 full:mesu-china.apple.com.akadns.net @cn
 full:mesu.apple.com @cn
 full:ml.cdn-apple.com @cn
-full:music.apple.com @cn
 full:oscdn.apple.com @cn
 full:oscdn.origin-apple.com.akadns.net @cn
 full:pancake.apple.com @cn

--- a/data/apple-music
+++ b/data/apple-music
@@ -1,0 +1,21 @@
+applemusic.berlin
+applemusic.co
+applemusic.com
+applemusic.com.au
+applemusic.hamburg
+applemusic.wang
+applemusicconnect.com
+applemusicfestival.com
+musickit.net
+wwwapplemusic.com
+
+music.apple.com
+
+# Domains and services below are available in China mainland
+full:amp-api-edge.music.apple.com @cn
+full:amp-api.music.apple.com @cn
+full:js-cdn.music.apple.com @cn
+full:music.apple.com @cn
+full:musicstatus.music.apple.com @cn
+full:play.music.apple.com @cn
+full:speedysub.music.apple.com @cn

--- a/data/apple-podcasts
+++ b/data/apple-podcasts
@@ -1,0 +1,7 @@
+applepodcasts.com
+
+podcasts.apple.com
+
+# Domains and services below are available in China mainland
+full:amp-api.podcasts.apple.com @cn
+full:podcasts.apple.com @cn

--- a/data/apple-tvplus
+++ b/data/apple-tvplus
@@ -1,5 +1,7 @@
 # Apple TV+
+full:amp-account.tv.apple.com
 full:apple-tv-plus-press.apple.com
+full:buy.tv.apple.com
 full:hls-amt.itunes.apple.com
 full:hls.itunes.apple.com
 full:np-edge.itunes.apple.com

--- a/data/apple-tvplus
+++ b/data/apple-tvplus
@@ -1,7 +1,5 @@
 # Apple TV+
-full:amp-account.tv.apple.com
 full:apple-tv-plus-press.apple.com
-full:buy.tv.apple.com
 full:hls-amt.itunes.apple.com
 full:hls.itunes.apple.com
 full:np-edge.itunes.apple.com

--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -9,6 +9,8 @@ include:7tv
 include:abema
 include:amc
 include:anime
+include:apple-music
+include:apple-podcasts
 include:apple-tvplus
 include:archiveofourown
 include:attwatchtv

--- a/data/itunes
+++ b/data/itunes
@@ -80,7 +80,9 @@ full:np-edge.itunes.apple.com @cn
 full:osxapps.itunes.apple.com @cn
 full:pd-nk.itunes.apple.com @cn
 full:pd.itunes.apple.com @cn
+full:play-edge.itunes.apple.com @cn
 full:play.itunes.apple.com @cn
+full:podcasts.itunes.apple.com @cn
 full:se-edge.itunes.apple.com @cn
 full:se2.itunes.apple.com @cn
 full:search.itunes.apple.com @cn


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

1. In `apple` category, I sorted the list alphabetically according to the comment titles, plus added some domains that have access points in China Mainland for Apple Podcasts
2. In `apple-tvplus` and `itunes`, I also updated some domains

## Proposal

I think we can extract the `apple` category into different categories, like `apple-music`, `apple-podcasts` and so on, because in this category there are so many domains with many services, especially in the following lines

https://github.com/v2fly/domain-list-community/blob/fcb888537ae69314c53b9ffae7dcc594fddfd8c6/data/apple#L752-L775

They are mixed in a category but with several different services, I think it's better to put them into different categories