### PR TITLE
Add kick.com

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -37,6 +37,7 @@ include:hulu
 include:imdb
 include:itunes
 include:iyf
+include:kick
 include:kingkonglive
 include:kkbox
 include:kktv

--- a/data/kick
+++ b/data/kick
@@ -1,0 +1,1 @@
+kick.com


### PR DESCRIPTION
Issue #3655

Kick is a general-purpose streaming service.
The site's key subsystems are subdomains, so only one domain has been added.