### PR TITLE
category-electronic-cn: fix espressif

### DIFF
--- a/data/category-electronic-cn
+++ b/data/category-electronic-cn
@@ -20,11 +20,7 @@ bouffalolab.com
 cxmt.com
 
 # 乐鑫信息科技
-#include:espressif
-esp8266.cn
-esp8266.com.cn
-espressif.cn
-espressif.com.cn
+include:espressif @-!cn
 
 # 华秋电子
 eda.cn

--- a/data/espressif
+++ b/data/espressif
@@ -1,3 +1,7 @@
-espressif.com
-esp32.com
-esp8266.com
+esp32.com @!cn
+esp8266.cn
+esp8266.com @!cn
+esp8266.com.cn
+espressif.cn
+espressif.com @!cn
+espressif.com.cn

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -321,7 +321,7 @@ wiki.gg
 
 # Others
 include:avaxhome
-include:espressif
+include:espressif @!cn
 include:familymart
 include:fzdm
 include:hkedcity


### PR DESCRIPTION
Since there is not a category file for the electronic, puting those domains out of the company file didn't present the right ownership.

Besides, may I suggest we add a new attribute for those domains with a edge(local) server, marking them with a region code is not right.
We can introduce a attribute likes `@edge=cn`

