### PR TITLE
Add adacpp.com to category-olympiad-in-informatics

### DIFF
--- a/data/category-olympiad-in-informatics
+++ b/data/category-olympiad-in-informatics
@@ -7,6 +7,7 @@ lingkou.cn
 
 51nod.com
 acwing.com
+adacpp.com
 hihocoder.com
 jisuanke.com
 kidsccshow.com


### PR DESCRIPTION
## Description

Add `adacpp.com` — AdaCpp (安达编程), a Chinese youth programming education platform focused on C++ / GESP / CSP-J (Olympiad in Informatics) courses, with an online judge at `oj.adacpp.com`.

## Evidence that the site is served from mainland China

- All A records resolve directly to a Tencent Cloud Beijing server `140.143.189.129` (no overseas CDN in front)
- ICP License: 京ICP备2023032206号-3 (shown in the site footer at https://adacpp.com)

The domain suffix covers the main site and the OJ subdomain.