### PR TITLE
Update kinopub: add new domains and API endpoints

### DIFF
--- a/data/kinopub
+++ b/data/kinopub
@@ -1,4 +1,5 @@
 kino.pub
+kino.watch
 kinopub.online
 kpdl.link
 
@@ -6,6 +7,11 @@ kpdl.link
 ahc.ovh # sub domains mirror
 gfw.ovh # sub domains mirror
 mos-gorsud.co # kinopub domain to generate a mirror site through gfw.ovh
+
+# kinopub API services
+api.alador.space
+m.alador.space
+support-kp.com
 
 # kinopub CDN servers
 cdn-service.space


### PR DESCRIPTION
### Description
Updates the `kinopub` list with new domains, API endpoints, and infrastructure servers.

### Changes
- Added `kino.watch` (which now serves as the primary domain).
- Added `api.alador.space` and `m.alador.space` under API services.
- Added the root domain `support-kp.com` to fully cover both `api.support-kp.com` and `api2.support-kp.com` API servers.
- Sorted all updated entries alphabetically in their respective sections.