### PR TITLE
remove invalid top level domain records

### DIFF
--- a/data/adobe-activation
+++ b/data/adobe-activation
@@ -39,11 +39,7 @@ full:lm.licenses.adobe.com
 full:lmlicenses.wip4.adobe.com
 full:na1r.services.adobe.com
 full:ood.opsource.net
-full:practivate.adobe
 full:practivate.adobe.com
-full:practivate.adobe.ipp
-full:practivate.adobe.newoa
-full:practivate.adobe.ntp
 full:wip.adobe.com
 full:wip1.adobe.com
 full:wip2.adobe.com

--- a/data/category-bank-ru
+++ b/data/category-bank-ru
@@ -4,7 +4,6 @@ alfabank.ru
 alfabank.st
 alfadirect.ru
 myapelsin.ru
-domain:alfabank.oavdo.amc
 
 # BBR
 bbr.ru

--- a/data/category-gov-ru
+++ b/data/category-gov-ru
@@ -124,7 +124,6 @@ omsk.ru         # Omsk Region
 orb.ru          # Orenburg Region
 oryol.ru        # Orel Region
 penza.ru        # Penza Region
-psk             # Pskov's local TLD
 psk.ru          # Pskov Region
 pskov.ru        # Pskov Region
 rnd.ru          # Rostov-on-Don City, Rostov Region

--- a/data/category-ir
+++ b/data/category-ir
@@ -4,7 +4,6 @@
 # Iran TLDs
 ir
 xn--mgba3a4f16a # .ایران
-xn--mgba3a4fra # .ايران
 
 include:category-ads-ir
 include:category-bank-ir

--- a/data/category-public-tracker
+++ b/data/category-public-tracker
@@ -155,7 +155,6 @@ full:pubt.net
 full:qg.lorzl.gq
 full:retracker.ip.ncnet.ru
 full:retracker.lanta.me
-full:retracker.local
 full:retracker.spark-rostov.ru
 full:retracker01-msk-virt.corbina.net
 full:run.publictracker.xyz

--- a/data/category-stun
+++ b/data/category-stun
@@ -244,7 +244,6 @@ full:stun.sippeer.dk
 full:stun.sipthor.net
 full:stun.siptraffic.com
 full:stun.siptrunk.com
-full:stun.sipus
 full:stun.skydrone.aero
 full:stun.skylink.ru
 full:stun.sma.de
@@ -265,7 +264,6 @@ full:stun.ssl7.net
 full:stun.stochastix.de
 full:stun.streamnow.ch
 full:stun.stunprotocol.org
-full:stun.stunprotocol.prg
 full:stun.symform.com
 full:stun.symplicity.com
 full:stun.sysadminman.net

--- a/data/google
+++ b/data/google
@@ -36,9 +36,6 @@ gle
 # All .gmail domains
 gmail
 
-# All .goo domains
-goo
-
 # All .goog domains
 goog
 

--- a/data/intel
+++ b/data/intel
@@ -1,8 +1,5 @@
 include:intel-dev
 
-# All .intel domains
-intel
-
 intel.ac
 intel.ae
 intel.af

--- a/data/konami
+++ b/data/konami
@@ -1,6 +1,3 @@
-# All .konami domains
-konami
-
 573.jp
 kgisystems.com
 kiwi.jp

--- a/data/tld-!cn
+++ b/data/tld-!cn
@@ -531,7 +531,6 @@ xn--h2breg3eve  #  भारतम् India
 xn--h2brj9c8c  #  भारोत India
 xn--mgbgu82a  #  ڀارت India
 xn--mgba3a4f16a  #  ایران Iran
-xn--mgba3a4fra  #  ايران Iran
 xn--mgbtx2b  #  عراق Iraq
 xn--mgbayh7gpa  #  الاردن Jordan
 xn--80ao21a  #  қаз Kazakhstan
@@ -761,7 +760,6 @@ gmx # 1&1 Mail & Media GmbH
 godaddy # GoDaddy
 goog # Google
 google # Google
-goo # Google
 guge # Google
 hangout # Google
 hkt # PCCW-HKT DataCom Services Limited


### PR DESCRIPTION
Can't find them in the IANA list:
.adobe
.intel
.goo (from google)
.konami
.xn--mgba3a4fra (Iran's Desired Variant String, not allocated yet)
.ipp (from adobe-activation)
.nowoa (from adobe-activation)
.ntp (from adobe-activation)
.psk (from category-ru, it may be only valid in Russia ISPs)

Suppose they are only valid in a local area network, not for public resolver:
.amc (from category-bank-ru, it looks like a package name)
.sipus (from category-stun)
.prg (from category-stun)
.local (from category-public-tracker, record full:retracker.local,
it is a Russian intranet domain)

Those TLDs should be put into either private file or mark them excluded from the v2ray rule