### PR TITLE
category-ai-cn: add yzsgo.com

### DIFF
--- a/data/category-ai-cn
+++ b/data/category-ai-cn
@@ -126,3 +126,6 @@ zhiexa.com
 
 # LinkNet 沪ICP备2025147287号-4
 linka2a.net
+
+# 鸭嘴兽AI (跨境电商 AI 助手) 粤ICP备2026075154号-1
+yzsgo.com


### PR DESCRIPTION
Add **yzsgo.com** (鸭嘴兽AI, an AI assistant service for cross-border e-commerce sellers) to `category-ai-cn`.

Evidence that the site is hosted in and serves mainland China:

- ICP licence: **粤ICP备2026075154号-1** (linked to beian.miit.gov.cn in the site footer of https://www.yzsgo.com)
- Hosted on Alibaba Cloud Beijing (`39.105.74.236`); consistent A records from Chinese public resolvers (223.5.5.5 / 119.29.29.29 / 114.114.114.114)
- All service subdomains (www / app / auth / api) resolve to the same mainland origin, so the bare-suffix entry covers them

Context: the user base consists of cross-border e-commerce sellers who commonly run proxy clients; without a geosite entry their traffic to this mainland site detours through overseas nodes and degrades. 