### PR TITLE
strip existed enterprise owned domain from category

### DIFF
--- a/data/category-ai-ru
+++ b/data/category-ai-ru
@@ -2,9 +2,7 @@
 aiesa.ru
 
 # Yandex Alice
-alice.yandex.net
-alice.yandex.ru
-alicepro.yandex.ru
+include:yandex-ai
 
 # CopyMonkey (AI copywriter)
 copymonkey.app

--- a/data/category-doh-cn
+++ b/data/category-doh-cn
@@ -11,12 +11,7 @@ httpdns.n.shifen.com @ads
 httpsdns.baidu.com @ads
 
 # Huawei Cloud
-httpdns-browser.platform.dbankcloud.cn @ads
-httpdns.c.cdnhwc2.com @ads
-httpdns.huaweicloud.com @ads
-httpdns.platform.dbankcloud.cn @ads
-httpdns.platform.dbankcloud.com @ads
-httpdns1.cc.cdnhwc5.com @ads
+include:huawei-doh
 
 # iqiyi
 dns.iqiyi.com @ads
@@ -43,9 +38,7 @@ httpdns.push.oppomobile.com @ads
 httpdns.ocloud.oppomobile.com @ads
 
 # Tencent
-dns.weixin.qq.com @ads
-dns.weixin.qq.com.cn @ads
-httpdns.kg.qq.com @ads
+include:tencent-doh
 
 # HeyTap
 httpdns.ocloud.heytapmobi.com @ads

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -31,8 +31,8 @@ qchannel03.cn
 # 神策数据
 sensorsdata.cn
 
-# category-httpdns-cn is mainly for advertising purpose
-include:category-httpdns-cn
+# category-doh-cn is mainly for advertising purpose
+include:category-doh-cn
 
 # 号码认证
 # include:category-number-verification-cn

--- a/data/huawei
+++ b/data/huawei
@@ -1,5 +1,6 @@
 include:huawei-dev
 include:huaweicloud
+include:huawei-doh
 
 abhouses.com
 agconnect.link

--- a/data/huawei-doh
+++ b/data/huawei-doh
@@ -1,0 +1,6 @@
+httpdns-browser.platform.dbankcloud.cn @ads
+httpdns.c.cdnhwc2.com @ads
+httpdns.huaweicloud.com @ads
+httpdns.platform.dbankcloud.cn @ads
+httpdns.platform.dbankcloud.com @ads
+httpdns1.cc.cdnhwc5.com @ads

--- a/data/tencent
+++ b/data/tencent
@@ -4,6 +4,8 @@ include:tencent-dev
 include:tencent-games
 include:tencent-tme
 include:yuewen
+# Tencent Wechat ads
+include:tencent-doh
 
 qq.xn--fiqs8s # qq.中国
 xn--r70as2s.xn--fiqs8s # 腾讯.中国

--- a/data/tencent-doh
+++ b/data/tencent-doh
@@ -1,0 +1,3 @@
+dns.weixin.qq.com @ads
+dns.weixin.qq.com.cn @ads
+httpdns.kg.qq.com @ads

--- a/data/yandex
+++ b/data/yandex
@@ -91,6 +91,8 @@ yastatic-net.ru
 yastatic.net
 yccdn.ru
 
+include:yandex-ai
+
 # Ads and tracking
 adfox.ru @ads
 adfox.yandex.ru @ads

--- a/data/yandex-ai
+++ b/data/yandex-ai
@@ -1,0 +1,3 @@
+alice.yandex.ru
+alice.yandex.net
+alicepro.yandex.ru


### PR DESCRIPTION
TODO:
category-game-platforms-download
data/category-game-accelerator-cn

I don't know what I should do for them, for example, the resources fqdn for the xbox, the xbox itself is a product name under the enterprise mircosoft