### PR TITLE
geolocation-cn: add api.blipsandchitz.me

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1003,6 +1003,7 @@ anfensi.com
 anruan.com
 aotrip.net
 aoyou.com
+api.blipsandchitz.me
 apk3.com
 apk8.com
 aplaybox.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -528,6 +528,8 @@ include:zhubajie
 7moor.com
 ## 在意空气
 air-matters.com
+## Hover Translate #3854
+full:api.blipsandchitz.me
 ## Alook 浏览器
 alookweb.com
 ## AniXPlayer
@@ -1003,7 +1005,6 @@ anfensi.com
 anruan.com
 aotrip.net
 aoyou.com
-api.blipsandchitz.me
 apk3.com
 apk8.com
 aplaybox.com


### PR DESCRIPTION
## Summary

Add `api.blipsandchitz.me` to `geolocation-cn`.

This is the production API endpoint used by Hover Translate---a new quick translation tool for Mac desktops. Feel free to reach out for a trial if you’re interested — everyone who’s tried it loves it!

## Network evidence

AliDNS, Google Public DNS, and Cloudflare DNS return the same records (verified 2026-07-16):

```text
api.blipsandchitz.me.
  CNAME alb-o3q3o6lo8fbwaqbjcf.cn-beijing.alb.aliyuncsslb.com.
  A     8.147.117.74
  A     39.107.228.174
```

The CNAME is an Alibaba Cloud Application Load Balancer in Beijing. APNIC identifies `8.128.0.0/11` as `ALICLOUD` with country `CN`, and `39.96.0.0 - 39.108.255.255` as `ALISOFT` with country `CN`.

Only `api.blipsandchitz.me` is included. The apex domain and `www` currently use Netlify and are intentionally excluded.
