### PR TITLE
Add chesscom list (chess.com, chesscomfiles.com)

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -20,6 +20,7 @@ include:bangumi
 include:boomerang
 include:bushiroad
 include:catchplay
+include:chesscom
 include:copymanga
 include:dailymotion
 include:dandanplay

--- a/data/chesscom
+++ b/data/chesscom
@@ -1,0 +1,2 @@
+chess.com
+chesscomfiles.com


### PR DESCRIPTION
Add a new `chesscom` list for Chess.com's service domains.

- `chess.com` — main site, API, and asset subdomains (`www`, `api`,
  `assets-configurator`, `assets-themes`, `assets-ds`, `assets-coaches`,
  `text-and-audio`, `live2`, etc.)
- `chesscomfiles.com` — user/game asset CDN (`images.chesscomfiles.com`)

**Data source:** network requests captured from the Chess.com web app.

The list has only two rules because all of Chess.com's own infrastructure
lives under these two apex domains, which already cover every observed
subdomain.

