### PR TITLE
category-ip-geo-detect: add more IP detection services

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -89,6 +89,7 @@ ipqualityscore.com
 ipquery.io
 ipregistry.co
 iproyal.com
+ipsimple.org
 ipstack.com
 ipverify.com
 ipw.cn @cn
@@ -112,6 +113,7 @@ myipaddress.com
 myiplookup.com
 mylocation.org
 nodedata.io
+nossl.sh
 osint.sh
 proxycheck.io
 realip.cc
@@ -149,6 +151,7 @@ full:checkip.dyn.com
 full:ip.comss.net
 full:ipv4-check-perf.radar.cloudflare.com
 full:ipv6-check-perf.radar.cloudflare.com
+full:myip.dnsomatic.com
 full:whatismyip.akamai.com
 geoip.noc.gov.ru
 ip.hetzner.com


### PR DESCRIPTION
External IP and geolocation detection services. Sources: https://nossl.sh, https://ipsimple.org, https://myip.dnsomatic.com