### PR TITLE
tech-ir: add pazhnetwork.com

### DIFF
--- a/data/category-tech-ir
+++ b/data/category-tech-ir
@@ -26,6 +26,7 @@ p30download.com
 p30download.ir
 parsonline.com
 parspack.com
+pazhnetwork.com
 picofile.com
 pishgaman.net
 rightel.ir


### PR DESCRIPTION
Adding pazhnetwork.com, an Iranian tech/network services company