### PR TITLE
geolocation-cn: add lubiao.wiki

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -480,6 +480,8 @@ guoxuedashi.com
 guoxuemi.com
 ## 科普中国
 kepuchina.cn
+## 路标 Wiki 豫ICP备2024043594号-2
+lubiao.wiki
 ## 国家图书馆
 nlc.cn
 ## 四川省文物考古研究院


### PR DESCRIPTION
## Summary

Add `lubiao.wiki` to `geolocation-cn`. The parent-domain rule also covers the site's `www` and `img` subdomains.

## Evidence

- Website: [路标 Wiki](https://www.lubiao.wiki/) is a Chinese-language Arknights knowledge/archive site operated in mainland China.
- ICP filing: `豫ICP备2024043594号-2`, displayed on the site's [About page](https://www.lubiao.wiki/about) and searchable through the [MIIT filing system](https://beian.miit.gov.cn/).
- Infrastructure: the site is served through Tencent Cloud CDN, with a Tencent Cloud Lighthouse origin in the `ap-shanghai` mainland region. Image assets are served through the same mainland CDN provider from Tencent Cloud COS.
- Mainland DNS results observed on 2026-07-29:
  - AliDNS `223.5.5.5` and DNSPod `119.29.29.29` both resolve `lubiao.wiki` through `lubiao.wiki.cdn.dnsv1.com`.
  - Both resolvers resolve `www.lubiao.wiki` through `www.lubiao.wiki.cdn.dnsv1.com`.
  - Both names currently return `61.170.88.228` (China Telecom, Shanghai) and `180.101.153.106` (China Telecom, Jiangsu).
  - No overseas CDN address was returned by either mainland resolver in these checks.

## Validation

- `go test ./...`
- `go run ./ --outputdir=<temp> --exportlists=category-ads-all,tld-cn,cn,tld-!cn,geolocation-!cn,apple,icloud`
