### PR TITLE
yandex: add yndx.net

### DIFF
--- a/data/yandex
+++ b/data/yandex
@@ -91,6 +91,7 @@ yastat.net
 yastatic-net.ru
 yastatic.net
 yccdn.ru
+yndx.net
 
 # Ads and tracking
 adfox.ru @ads


### PR DESCRIPTION
sandie.yndx.net
Addresses:  2a0e:fd87:8066::2
          84.252.162.38

  Domain Name: YNDX.NET
   Registry Domain ID: 1656567507_DOMAIN_NET-VRSN
   Registrar WHOIS Server: whois.nic.ru
   Registrar URL: http://nic.ru
Name Server: NS5.YANDEX.RU
Name Server: NS6.YANDEX.RU

<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

