### PR TITLE
clean up redundant includes

### DIFF
--- a/data/category-dev-cn
+++ b/data/category-dev-cn
@@ -5,7 +5,6 @@ include:baltamatica
 include:cnblogs
 include:csdn
 include:deepin @-!cn
-include:gitee
 include:goproxy
 include:huawei-dev
 include:juejin

--- a/data/category-porn
+++ b/data/category-porn
@@ -51,7 +51,6 @@ include:nudevista
 include:pawchive
 include:picacg
 include:playboy
-include:pornhub
 include:pornpros
 include:projectpoi
 include:sehuatang

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -18,8 +18,6 @@ include:category-proxy-tunnels
 include:artstation
 include:dribbble
 include:dyna
-include:flickr
-include:fonts
 include:fontsinuse
 include:gettyimages
 include:glyphs
@@ -43,11 +41,9 @@ include:volvo
 
 # Bank & Finance
 include:category-finance
-include:dowjones
 include:mastercard
 include:paypal
 include:softbank
-include:stripe
 include:visa
 ## アプリペイ
 app-pay.jp
@@ -87,7 +83,6 @@ include:edx
 include:egghead
 include:embl
 include:freecodecamp
-include:kaggle
 include:khanacademy
 include:laracasts
 include:libgen
@@ -138,9 +133,6 @@ include:streamable
 include:category-forums
 include:category-social-media-!cn
 
-# IPFS
-include:category-ipfs
-
 # Media & News & Press
 include:category-media
 include:pugpig
@@ -150,9 +142,6 @@ include:category-orgs
 
 # Porn
 include:category-porn
-
-# Religion
-include:falungong
 
 # Services & Softwares
 include:category-android-app-download
@@ -173,7 +162,6 @@ include:rsshub-3rd
 include:accuweather
 include:adblock
 include:adblockplus
-include:addthis
 include:addtoany
 include:adguard
 include:aptoide
@@ -185,7 +173,6 @@ include:chatango
 include:cloudconvert
 include:contentful
 include:cuttly
-include:digitalocean
 include:disqus
 include:duckduckgo
 include:easylist
@@ -229,7 +216,6 @@ include:reurl
 include:sb
 include:setapp
 include:sharethis
-include:shopify
 include:slideshare
 include:sourceforge
 include:squareup
@@ -329,7 +315,6 @@ include:huanghuagang
 include:lavteam
 include:mcdonalds
 include:rb
-include:reagroup
 include:scenesource
 include:starbucks
 include:tsquare


### PR DESCRIPTION
Reasons:

Redundant: `addthis -> geolocation-!cn`
Existing: `addthis -> oracle -> category-companies -> geolocation-!cn`

Redundant: `category-ipfs -> geolocation-!cn`
Existing: `category-ipfs -> category-anticensorship -> geolocation-!cn`

Redundant: `digitalocean -> geolocation-!cn`
Existing: `digitalocean -> category-companies -> geolocation-!cn`

Redundant: `dowjones -> geolocation-!cn`
Existing: `dowjones -> newscorp -> category-media -> geolocation-!cn`

Redundant: `falungong -> geolocation-!cn`
Existing: `falungong -> category-media -> geolocation-!cn`

Redundant: `flickr -> geolocation-!cn`
Existing: `flickr -> yahoo -> category-companies -> geolocation-!cn`

Redundant: `fonts -> geolocation-!cn`
Existing: `fonts -> monotype -> geolocation-!cn`

Redundant: `gitee -> category-dev-cn`
Existing: `gitee -> oschina -> category-dev-cn`

Redundant: `kaggle -> geolocation-!cn`
Existing: `kaggle -> google -> alphabet -> category-companies -> geolocation-!cn`

Redundant: `pornhub -> category-porn`
Existing: `pornhub -> mindgeek-porn -> category-porn`

Redundant: `reagroup -> geolocation-!cn`
Existing: `reagroup -> newscorp -> category-media -> geolocation-!cn`

Redundant: `shopify -> geolocation-!cn`
Existing: `shopify -> category-ecommerce -> geolocation-!cn`

Redundant: `stripe -> geolocation-!cn`
Existing: `stripe -> category-finance -> geolocation-!cn`
