### PR TITLE
Add additional JetBrains domains

### DIFF
--- a/data/category-ai-!cn
+++ b/data/category-ai-!cn
@@ -9,6 +9,7 @@ include:github-copilot
 include:google-deepmind
 include:groq
 include:huggingface
+include:jetbrains-ai
 include:liveperson
 include:manus
 include:openai

--- a/data/category-dev
+++ b/data/category-dev
@@ -32,7 +32,6 @@ include:homebrew
 include:intel-dev
 include:java
 include:jetbrains
-include:jetbrains-ai
 include:jfrog
 include:kubernetes
 include:microsoft-dev

--- a/data/jetbrains
+++ b/data/jetbrains
@@ -1,3 +1,6 @@
+# https://www.jetbrains.com/legal/websites/
+include:jetbrains-ai
+
 datalore.io
 intellij.com
 intellij.net

--- a/data/jetbrains
+++ b/data/jetbrains
@@ -6,10 +6,18 @@ jb.gg
 jetbrains.cloud
 jetbrains.com
 jetbrains.com.cn @cn
+jetbrains.dev
 jetbrains.net
+jetbrains.org
+jetbrains.ru
 jetbrains.space
 jetbrains.team
+kotl.in
+kotlinconf.com
 kotlinlang.org
+ktor.io
+myjetbrains.com
+talkingkotlin.com
 youtrack.cloud
 
 cdn.jetbrains.com @cn


### PR DESCRIPTION
## Why
Plugin downloads in IntelliJ IDEA were consistently failing with the 
existing domain list. Added missing JetBrains domains to allow proper 
connectivity for IDE services.

## Source
https://iplist.opencck.org/?format=text&data=domains&wildcard=1&site=jetbrains.com

## Added domains
- jetbrains.dev
- jetbrains.org
- jetbrains.ru
- kotl.in
- kotlinconf.com
- ktor.io
- myjetbrains.com
- talkingkotlin.com