### PR TITLE
google-deepmind: add notebook.google.com

### DIFF
--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -32,9 +32,9 @@ full:daily-cloudcode-pa.googleapis.com
 # NotebookLM
 full:notebooklm-pa.googleapis.com
 full:notebooklm.googleapis.com
+notebook.google.com
 notebooklm.google
 notebooklm.google.com
-notebook.google.com
 
 # Jules
 jules.google

--- a/data/google-deepmind
+++ b/data/google-deepmind
@@ -34,6 +34,7 @@ full:notebooklm-pa.googleapis.com
 full:notebooklm.googleapis.com
 notebooklm.google
 notebooklm.google.com
+notebook.google.com
 
 # Jules
 jules.google


### PR DESCRIPTION
Add notebook.google.com

This this actual subdomain for notebook