### PR TITLE
Add sonemic list (Rate Your Music, Glitchwave)

### DIFF
--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -64,6 +64,7 @@ include:plutotv
 include:pocketcasts
 include:primevideo
 include:radiko
+include:rateyourmusic
 include:roku
 include:showtimeanytime
 include:sling

--- a/data/category-entertainment
+++ b/data/category-entertainment
@@ -64,10 +64,10 @@ include:plutotv
 include:pocketcasts
 include:primevideo
 include:radiko
-include:rateyourmusic
 include:roku
 include:showtimeanytime
 include:sling
+include:sonemic
 include:sonypictures
 include:soundcloud
 include:spotify

--- a/data/rateyourmusic
+++ b/data/rateyourmusic
@@ -1,9 +1,0 @@
-rateyourmusic.com
-
-sonematic.net
-full:cdn.sonematic.net
-
-snmc.io
-full:e.snmc.io
-
-sonemic.com

--- a/data/rateyourmusic
+++ b/data/rateyourmusic
@@ -1,0 +1,9 @@
+rateyourmusic.com
+
+sonematic.net
+full:cdn.sonematic.net
+
+snmc.io
+full:e.snmc.io
+
+sonemic.com

--- a/data/sonemic
+++ b/data/sonemic
@@ -1,0 +1,15 @@
+# Glitchwave, video game database
+glitchwave.com
+
+# Rate Your Music
+rateyourmusic.com
+
+# Rate Your Music forums
+rym.fm
+
+# Image and static asset CDN
+snmc.io
+sonematic.net
+
+# Sonemic project site
+sonemic.com


### PR DESCRIPTION
Adds a list for [Rate Your Music](https://rateyourmusic.com), a music
database and rating community, and includes it in `category-entertainment`
alongside the other music services (bandcamp, lastfm, deezer, tidal).

Domains and how they were verified:

- `rateyourmusic.com` — main site. Certificate transparency shows `www`,
  `beta` and the localized `de`/`fr`/`pl`/`ru` subdomains, all on the same
  Cloudflare anycast IPs, so the parent domain rule covers them.
- `snmc.io` — image and static asset CDN (`e.snmc.io`, `v.snmc.io`).
  Delegated to `ns1`/`ns2.sonemic.com`, so the whole domain belongs to the
  same operator.
- `sonemic.com` — project site for the ongoing RYM rewrite, run by the same
  company.

Included in `category-entertainment`, which flows into `geolocation-!cn`.
Verified with `go run ./ --datapath=./data`.
