### PR TITLE
Add new Ozon domains to the list

### DIFF
--- a/data/ozon
+++ b/data/ozon
@@ -7,14 +7,17 @@ ocourier.ru
 ozon-dostavka.ru
 ozon-credit.ru
 ozon-tech.ru
+ozon.app
 ozon.by
 ozon.com
 ozon.com.by
 ozon.com.kz
 ozon.dev
 ozon.express
+ozon.global
 ozon.kz
 ozon.li
+ozon.market
 ozon.ru
 ozon.tech
 ozon.tm


### PR DESCRIPTION
Added the following Ozon domains:

- ozon.app
- ozon.global
- ozon.market

These domains are used by the Ozon mobile application and improve compatibility with routing rules.
Sources: 
- https://russia.iplist.opencck.org/?format=text&data=domains&wildcard=1&site=ozon.ru
- https://github.com/rekryt/iplist