### PR TITLE
Create flyio

### DIFF
--- a/data/fly
+++ b/data/fly
@@ -1,0 +1,2 @@
+fly.dev
+fly.io

--- a/data/flyio
+++ b/data/flyio
@@ -1,2 +1,3 @@
 fly.dev
 fly.io
+flyio.net

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -182,7 +182,7 @@ include:evernote
 include:faststone
 include:feedly
 include:figma
-include:fly
+include:flyio
 include:gofundme
 include:gravatar
 include:hcaptcha

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -182,6 +182,7 @@ include:evernote
 include:faststone
 include:feedly
 include:figma
+include:fly
 include:gofundme
 include:gravatar
 include:hcaptcha


### PR DESCRIPTION
### Summary
Add a new domain list category `fly` for Fly.io (`fly.dev`, `fly.io`).

### Reason
Fly.io is a public cloud platform for running application servers close to users. It allows developers to deploy full-stack applications, databases, and Docker containers globally on edge infrastructure. Adding a dedicated domain list category for Fly.io helps users organize and manage domain rules for this platform.