### PR TITLE
`category-anticensorship`: add more domains

### DIFF
--- a/data/category-anticensorship
+++ b/data/category-anticensorship
@@ -12,19 +12,23 @@ include:v2ray
 include:vpngate
 include:remnawave
 
+full:matsuridayo.github.io
 full:metacubex.github.io
 full:rabbit-hole-1.gitbook.io
 full:throneproj.github.io
 full:trojan-gfw.github.io
 full:xtls.github.io
 
+2dust.link
 ahmia.fi
 akasha.world
+amnezia.org
 browserleaks.com
 bypasscensorship.org
 censorship.ai
 clashmi.app
 clashparty.org
+clashverge.dev
 clashyun.com
 dat.foundation
 democracy.earth
@@ -46,7 +50,9 @@ jitsi.org
 karing.app
 lokinet.org
 metacubex.one
+nsloon.com
 ntc.party
+onexray.com
 onionshare.org
 ooni.org
 openvpn.net
@@ -56,9 +62,12 @@ proxifier.com
 psiphon.ca
 psiphon3.com
 sagernet.org
+shadowlaunch.com
 shadowsocks.org
 sing-box.app
 sspanel.net
+stash.wiki
+stash.ws
 stunnel.org
 telex.cc
 tribler.org
@@ -68,7 +77,9 @@ twister.net.co
 uproxy.org
 vpnrouter.homes
 vuvuzela.io
+wgtunnel.com
 whonix.org
 wikileaks.org
 wireguard.com
+wiresock.net
 zeronet.io

--- a/data/category-anticensorship
+++ b/data/category-anticensorship
@@ -12,6 +12,9 @@ include:v2ray
 include:vpngate
 include:remnawave
 
+full:metacubex.github.io
+full:rabbit-hole-1.gitbook.io
+full:throneproj.github.io
 full:trojan-gfw.github.io
 full:xtls.github.io
 
@@ -20,11 +23,15 @@ akasha.world
 browserleaks.com
 bypasscensorship.org
 censorship.ai
+clashmi.app
+clashparty.org
 clashyun.com
 dat.foundation
 democracy.earth
 eff.org
 ffprofile.com
+flclashx.app
+flowvy.io
 freenetproject.org
 fteproxy.org
 geti2p.net
@@ -34,7 +41,9 @@ guardianproject.info
 happ.info
 happ.su
 hiddify.com
+incy.cc
 jitsi.org
+karing.app
 lokinet.org
 metacubex.one
 ntc.party
@@ -42,6 +51,7 @@ onionshare.org
 ooni.org
 openvpn.net
 privacytools.io
+prizrak.app
 proxifier.com
 psiphon.ca
 psiphon3.com


### PR DESCRIPTION
[metacubex.github.io](https://metacubex.github.io/Meta-Docs) redirects to [wiki.metacubex.one](https://wiki.metacubex.one) (taken from the main page at [github.com/MetaCubeX/Meta-Docs](https://github.com/MetaCubeX/Meta-Docs))

[flclashx.app](https://flclashx.app) is the site of the VPN client [FlClashX](https://github.com/pluralplay/FlClashX)
[prizrak.app](https://docs.prizrak.app) is the site of the VPN client [Prizrak-box](https://github.com/legiz-ru/Prizrak-Box)
[flowvy.io](https://docs.flowvy.io) is the site of the VPN client [Flowvy](https://github.com/flowvy-proxy/desktop)
[rabbit-hole-1.gitbook.io](https://rabbit-hole-1.gitbook.io) is the site of the VPN client [Rabbit Hole](https://apps.apple.com/fi/app/rabbithole-vpn-client/id6683309629)
[throneproj.github.io](https://throneproj.github.io) is the site of the VPN client [Throne](https://github.com/throneproj/Throne)
[clashmi.app](https://clashmi.app) is the site of the VPN client [Clash Mi](https://github.com/KaringX/clashmi)
[karing.app](https://karing.app) is the site of the VPN client [Karing](https://github.com/KaringX/karing)
[clashparty.org](https://clashparty.org) is the site of the VPN client [Clash Party](https://github.com/mihomo-party-org/clash-party)
[incy.cc](https://incy.cc) is the site of the VPN client [INCY](https://github.com/INCY-DEV/incy-platforms)