### PR TITLE
`category-doh`: add more domains

### DIFF
--- a/data/category-doh
+++ b/data/category-doh
@@ -294,6 +294,7 @@ full:public.ns.nwps.fi
 full:kids.ns.nwps.fi
 
 ## ASTRACAT DNS
+full:dns.astracat.ru
 full:frd4wvnobp.cloudflare-gateway.com
 
 ## DNSGuard
@@ -301,3 +302,16 @@ full:dnsguard.pub
 
 ## 18Bit DNS
 full:doh.18bit.cn
+
+## Malw DNS
+full:5u35p8m9i7.cloudflare-gateway.com
+full:dns.malw.link
+
+## Mafioznik DNS
+full:dns.mafioznik.xyz
+
+## GeoHide
+full:dns.geohide.ru
+
+## XBox DNS
+full:xbox-dns.ru


### PR DESCRIPTION
All these DNS servers are for bypassing geoblocking in Russia:

**[info](https://github.com/ASTRACAT2022/host-DNS#1-%D0%BD%D0%B0%D1%88%D0%B8-dns-%D1%81%D0%B5%D1%80%D0%B2%D0%B5%D1%80%D1%8B)** [dns.astracat.ru](https://dns.astracat.ru/dns-query)

**[info](https://info.dns.malw.link)** [dns.malw.link](https://dns.malw.link/dns-query) & [5u35p8m9i7.cloudflare-gateway.com](https://5u35p8m9i7.cloudflare-gateway.com/dns-query)

**[info](https://freedom.mafioznik.xyz/)** [dns.mafioznik.xyz](https://dns.mafioznik.xyz/dns-query)

**[info](https://dns.geohide.ru:8443)** [dns.geohide.ru](https://dns.geohide.ru:444/dns-query)

**[info](https://xbox-dns.ru/#setup)** [xbox-dns.ru](https://xbox-dns.ru/dns-query)