### PR TITLE
Expand AirChina Domains

### DIFF
--- a/data/airchina
+++ b/data/airchina
@@ -1,2 +1,43 @@
-airchina.com.cn # 中国国际航空
-airchinacargo.com # 中国国际货运航空
+airchina.ae @!cn
+airchina.at @!cn
+airchina.ca @!cn
+airchina.ch @!cn
+airchina.cn
+airchina.com
+airchina.com.au @!cn
+airchina.com.br @!cn
+airchina.com.cn
+airchina.com.my @!cn
+airchina.com.ph @!cn
+airchina.com.tw @!cn
+airchina.co.id @!cn
+airchina.co.in @!cn
+airchina.co.th @!cn
+airchina.co.uk @!cn
+airchina.de @!cn
+airchina.dk @!cn
+airchina.es @!cn
+airchina.fr @!cn
+airchina.gr @!cn
+airchina.hk @!cn
+airchina.hu @!cn
+airchina.it @!cn
+airchina.jp @!cn
+airchina.kr @!cn
+airchina.nz @!cn
+airchina.se @!cn
+airchina.sg @!cn
+airchina.us @!cn
+airchina.vn @!cn
+
+airchinacargo.com
+
+airchinalimited.cn
+airchinalimited.com
+airchinalimited.com.cn
+
+fly-airchina.com
+
+phoenixmiles.cn
+phoenixmiles.com
+phoenixmiles.com.cn

--- a/data/airchina
+++ b/data/airchina
@@ -32,6 +32,8 @@ airchina.vn @!cn
 
 airchinacargo.com
 
+airchinagroup.com
+
 airchinalimited.cn
 airchinalimited.com
 airchinalimited.com.cn

--- a/data/airchina
+++ b/data/airchina
@@ -3,6 +3,10 @@ airchina.at @!cn
 airchina.ca @!cn
 airchina.ch @!cn
 airchina.cn
+airchina.co.id @!cn
+airchina.co.in @!cn
+airchina.co.th @!cn
+airchina.co.uk @!cn
 airchina.com
 airchina.com.au @!cn
 airchina.com.br @!cn
@@ -10,10 +14,6 @@ airchina.com.cn
 airchina.com.my @!cn
 airchina.com.ph @!cn
 airchina.com.tw @!cn
-airchina.co.id @!cn
-airchina.co.in @!cn
-airchina.co.th @!cn
-airchina.co.uk @!cn
 airchina.de @!cn
 airchina.dk @!cn
 airchina.es @!cn

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -306,6 +306,7 @@ touhouwiki.net
 wiki.gg
 
 # Others
+include:airchina @!cn
 include:avaxhome
 include:espressif @!cn
 include:familymart

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -306,7 +306,6 @@ touhouwiki.net
 wiki.gg
 
 # Others
-include:airchina @!cn
 include:avaxhome
 include:espressif @!cn
 include:familymart

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -399,7 +399,7 @@ zgjx.cn
 
 # Public transportation
 ## 中国国际航空
-include:airchina
+include:airchina @-!cn
 ## 海南航空
 include:hainanairlines
 ## 长安航空


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

起因是发现国航 app 有在用 m.airchina.com 而纯 com 没有被收录。

非 `@!cn` 的新增域名来源于在工信部备案平台查询 [中国国际航空股份有限公司] 主体备案域名，`@!cn` 来自 `airchina.com.br` 的地区切换按钮。

