### PR TITLE
category-ip-geo-detect: add ip-check-perf.radar.cloudflare.com

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -148,6 +148,7 @@ wtfismyip.com
 full:checkip.amazonaws.com
 full:checkip.dyndns.org
 full:checkip.dyn.com
+full:ip-check-perf.radar.cloudflare.com
 full:ip.comss.net
 full:ipv4-check-perf.radar.cloudflare.com
 full:ipv6-check-perf.radar.cloudflare.com


### PR DESCRIPTION
Dual-stack endpoint used by Cloudflare Radar for IP detection, alongside the already listed `ipv4-check-perf` and `ipv6-check-perf` variants.