### PR TITLE
Update Steam in data/steam

### DIFF
--- a/data/steam
+++ b/data/steam
@@ -69,8 +69,8 @@ dota2.com.cn @cn
 dota2.wmsj.cn @cn
 wmsjsteam.com @cn
 
-# Steam更新
-client-update.queniuqe.com @cn
+# Steam CDN
+queniuqe.com @cn
 
 # 新流云
 dl.steam.clngaa.com @cn


### PR DESCRIPTION
The domain `queniuqe.com` is also used for CDN resources on the Steam website (e.g., `store.cdn.queniuqe.com` and `shared.cdn.queniuqe.com`); it is recommended to change `client-update.queniuqe.com` to the main domain format.

<img width="2382" height="1296" alt="屏幕截图 2026-08-10 151443" src="https://github.com/user-attachments/assets/32d8c800-656a-42fd-994f-b18b6a38f018" />
