### PR TITLE
Add NixOS (again)

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -37,6 +37,7 @@ include:kubernetes
 include:microsoft-dev
 include:mongodb
 include:nginx
+include:nixos
 include:openwrt
 include:perl
 include:polymer
@@ -123,7 +124,6 @@ neovim.io
 netfilter.org
 newpipe.net
 nftables.org
-nixos.org
 nodesource.com
 notepad-plus-plus.org
 openresty.org

--- a/data/nixos
+++ b/data/nixos
@@ -1,0 +1,16 @@
+nix.dev
+nix.store
+nixcon.org
+nixcon2017.org
+nixlang.com
+nixos.org
+nixpkgs.org
+
+# Unofficial
+
+full:nix-community.github.io
+
+builtwithnix.org
+mynixos.com
+nix-community.org
+nixos.wiki


### PR DESCRIPTION
Previously, the geosite `nixos` was added in #2027. After that, this geosite was removed and moved to `category-dev` because it had only one domain ([nixos.org](https://nixos.org)).

This PR adds geosite `nixos` again with several domains:

[nixos.org](https://nixos.org) is the official site (taken from the main page at https://github.com/NixOS/nix)
[nix.dev](https://nix.dev) is the official site (taken from the main page at https://github.com/NixOS/nix.dev)
[nixcon.org](https://nixcon.org) and [nixcon2017.org](https://nixcon2017.org) are the official sites of the Nix conference (taken from https://github.com/NixOS/org/blob/main/doc/nixcon.md)

[nix.store](https://nix.store) and [nixlang.com](https://nixlang.com) redirect to [nixos.org](https://nixos.org)
[nixpkgs.org](https://nixpkgs.org) redirects to [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs)

[nix-community.org](https://nix-community.org) is the site of [nix-community](https://github.com/nix-community) (taken from the main page at https://github.com/nix-community)
[nix-community.github.io](https://nix-community.github.io) is the site of [nix-community](https://github.com/nix-community) (taken from the main page at https://github.com/nix-community/home-manager)
[builtwithnix.org](https://builtwithnix.org) is the site of [nix-community](https://github.com/nix-community) (taken from the main page at https://github.com/nix-community/builtwithnix.org)

[mynixos.com](https://mynixos.com) is the site of a community (info is taken from https://mynixos.com/about)
[nixos.wiki](https://nixos.wiki) is the site of a community (info is taken from https://nixos.wiki/wiki/NixOS_Wiki:About)

The geosite [`archlinux`](https://github.com/v2fly/domain-list-community/blob/90b6bb94709c014918d83a4eb63f3593b7d00eb8/data/archlinux#L7) has a block of unofficial domains. I decided to do the same