### PR TITLE
`yandex`: add yandex.it

### DIFF
--- a/data/yandex
+++ b/data/yandex
@@ -49,6 +49,7 @@ yandex.ee
 yandex.eu
 yandex.fi
 yandex.fr
+yandex.it
 yandex.jobs
 yandex.kg
 yandex.kz


### PR DESCRIPTION
The domain was found in the SSL certificate.

It redirects to [yandex.com](https://yandex.com)