### PR TITLE
geolocation-cn: fix bambulab domain

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -588,7 +588,8 @@ yingyonghui.com
 ## 问答库
 asklib.com
 ## 拓竹科技
-bambulab.com
+bambulab.cn
+makerworld.com.cn
 bblmw.com
 ## BOSS 直聘
 bosszhipin.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->
bambulab has segregated its services into overseas (bambulab.com and makerworld.com) and mainland (bambulab.com.cn and makerworld.com.cn). Visiting the former without a proxy will redirect you to the latter.
