### PR TITLE
Update category-ru: add bitrix; add ktalk to kontur; add voidboost to vokino

### DIFF
--- a/data/bitrix
+++ b/data/bitrix
@@ -1,0 +1,15 @@
+# NAME: Bitrix
+# DESC: 1C-Bitrix and Bitrix24 infrastructure (CRM, cloud services, updates, telephony)
+# NOTE: Regional domains (like .de, .eu, .cn, etc.) are intentionally excluded as this list is intended for category-ru.
+
+1c-bitrix.ru
+bitrix.info
+bitrix24.com
+bitrix24.net
+bitrix24.ru
+bitrix24.tech
+bitrix24public.com
+bitrix24shop.ru
+bitrix24site.ru
+bitrixphone.com
+bitrixsoft.com

--- a/data/category-ru
+++ b/data/category-ru
@@ -23,6 +23,7 @@ include:category-travel-ru
 
 # Russian companies
 include:beget
+include:bitrix
 include:carrotquest
 include:cdek
 include:comssone

--- a/data/kontur
+++ b/data/kontur
@@ -1,5 +1,7 @@
-kontur.ru
-kontur.host
-kontur-inc.com
 full:metrika.kontur.ru @ads
 full:sentry.kontur.host @ads
+kontur-inc.com
+kontur.host
+kontur.ru
+ktalk.host
+ktalk.ru

--- a/data/vokino
+++ b/data/vokino
@@ -22,4 +22,5 @@ stream-balancer-allo-1.live
 stream-balancer-allo-1.site
 videobase.biz
 vkvideo.cloud
+voidboost.one
 werkecdn.me


### PR DESCRIPTION
This PR contains three updates to `category-ru` and related lists:

**1. Add new `bitrix` list**
Added core infrastructure domains for 1C-Bitrix and Bitrix24 (CRM, cloud services, updates, telephony). Included in `category-ru` under "Russian companies".
*Note: International regional domains (e.g., `bitrix24.de`, `bitrix24.eu`, etc.) are intentionally omitted as the focus is routing within the `category-ru` context.*
*Reference: [Bitrix24 server network requirements](https://itforprof.com/platformy/porty-i-servisy-bitriks24-korobka/)*

**2. Update `kontur`**
Added `ktalk.ru` (Kontur.Talk video conferencing service).
*Reference: [Kontur.Talk technical requirements](https://support.kontur.ru/talk/41117-texnicheskie_trebovaniya)*

**3. Update `vokino`**
Added `voidboost.one` to the existing list.

### Verification
- Bitrix domains verified via official Helpdesk documentation and technical guidelines for self-hosted VMBitrix.
- Kontur Talk domain verified via official support pages.