### PR TITLE
geolocation-cn: add metax-tech.com

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1624,6 +1624,7 @@ meika360.com
 meilishuo.com
 meimingteng.com
 meiqia.com
+metax-tech.com # 沐曦集成电路 (Chinese GPU vendor)
 meloong.com # 蜀ICP备2024111431号
 mengtuoshi.wang
 miaobolive.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -1624,7 +1624,7 @@ meika360.com
 meilishuo.com
 meimingteng.com
 meiqia.com
-metax-tech.com # 沐曦集成电路 (Chinese GPU vendor)
+metax-tech.com # 沪ICP备2020031767号-1
 meloong.com # 蜀ICP备2024111431号
 mengtuoshi.wang
 miaobolive.com


### PR DESCRIPTION
## Description

Adds `metax-tech.com` to `geolocation-cn`.

- metax-tech.com is the official developer/documentation site of **MetaX (沐曦集成电路)**, a Chinese GPU vendor headquartered in Shanghai.
- ICP license: **沪ICP备2020031767号-1** (shown in the site footer).
- The site is hosted in and directly reachable from mainland China networks, but currently times out when accessed from foreign exits — so it should be classified as CN.

## Testing

- Direct access from a CN network: HTTP 200 in ~0.5s
- Access via an overseas proxy exit: connection timeout