### PR TITLE
category-ip-geo-detect: add reallyfreegeoip.org

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -117,6 +117,7 @@ nossl.sh
 osint.sh
 proxycheck.io
 realip.cc
+reallyfreegeoip.org
 seeip.org
 showip.net
 showmyip.com


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

External IP and geolocation detection services. Source https://reallyfreegeoip.org