### PR TITLE
Add new Warner CDN domain to geosite:hbo

### DIFF
--- a/data/hbo
+++ b/data/hbo
@@ -61,6 +61,7 @@ maxgo.com
 redbyhbo.com
 
 # CDNs
+h264.io
 hbo.com.c.footprint.net
 hbo.com.edgesuite.net
 hbo.map.fastly.net


### PR DESCRIPTION
Add a new CDN domain used by Warner Bros. Discovery for HBO Max to the CDN section of geosite:hbo. 