### PR TITLE
feat(amplitude): add data/amplitude with complete domain list

### DIFF
--- a/data/amplitude
+++ b/data/amplitude
@@ -1,0 +1,42 @@
+amplitude.com
+analytics.amplitude.com
+analytics.eu.amplitude.com
+api-secure.amplitude.com @ads
+api-secure.eu.amplitude.com @ads
+api-sr.amplitude.com @ads
+api-sr.eu.amplitude.com @ads
+api.amplitude.com @ads
+api.eu.amplitude.com @ads
+api2.amplitude.com @ads
+app.amplitude.com
+app.eu.amplitude.com
+assistant-api.amplitude.com @ads
+assistant-api.eu.amplitude.com @ads
+cdn.amplitude.com @ads
+cdn.eu.amplitude.com @ads
+core.amplitude.com
+core.eu.amplitude.com
+data.amplitude.com
+data.eu.amplitude.com
+data-api.amplitude.com
+data-api.eu.amplitude.com
+engagement-static.amplitude.com @ads
+engagement-static.eu.amplitude.com @ads
+eu.amplitude.com
+experiment.amplitude.com
+experiment.eu.amplitude.com
+gs.amplitude.com @ads
+gs.eu.amplitude.com @ads
+lab.amplitude.com @ads
+lab.eu.amplitude.com @ads
+mcp.amplitude.com
+mcp.eu.amplitude.com
+privacy.amplitude.com
+privacy.eu.amplitude.com
+profile-api.amplitude.com
+profile-api.eu.amplitude.com
+recommend.amplitude.com
+regionconfig.amplitude.com @ads
+regionconfig.eu.amplitude.com @ads
+sr-client-cfg.amplitude.com @ads
+sr-client-cfg.eu.amplitude.com @ads

--- a/data/amplitude
+++ b/data/amplitude
@@ -1,6 +1,4 @@
 amplitude.com
-analytics.amplitude.com
-analytics.eu.amplitude.com
 api-secure.amplitude.com @ads
 api-secure.eu.amplitude.com @ads
 api-sr.amplitude.com @ads
@@ -8,34 +6,16 @@ api-sr.eu.amplitude.com @ads
 api.amplitude.com @ads
 api.eu.amplitude.com @ads
 api2.amplitude.com @ads
-app.amplitude.com
-app.eu.amplitude.com
 assistant-api.amplitude.com @ads
 assistant-api.eu.amplitude.com @ads
 cdn.amplitude.com @ads
 cdn.eu.amplitude.com @ads
-core.amplitude.com
-core.eu.amplitude.com
-data.amplitude.com
-data.eu.amplitude.com
-data-api.amplitude.com
-data-api.eu.amplitude.com
 engagement-static.amplitude.com @ads
 engagement-static.eu.amplitude.com @ads
-eu.amplitude.com
-experiment.amplitude.com
-experiment.eu.amplitude.com
 gs.amplitude.com @ads
 gs.eu.amplitude.com @ads
 lab.amplitude.com @ads
 lab.eu.amplitude.com @ads
-mcp.amplitude.com
-mcp.eu.amplitude.com
-privacy.amplitude.com
-privacy.eu.amplitude.com
-profile-api.amplitude.com
-profile-api.eu.amplitude.com
-recommend.amplitude.com
 regionconfig.amplitude.com @ads
 regionconfig.eu.amplitude.com @ads
 sr-client-cfg.amplitude.com @ads

--- a/data/amplitude
+++ b/data/amplitude
@@ -1,3 +1,4 @@
+# https://github.com/v2fly/domain-list-community/pull/3997
 amplitude.com
 api-secure.amplitude.com @ads
 api-secure.eu.amplitude.com @ads

--- a/data/category-ads
+++ b/data/category-ads
@@ -5,6 +5,7 @@ include:36kr @ads
 include:adobe @ads
 include:alibaba @ads
 include:amazon @ads
+include:amplitude @ads
 include:apple @ads
 include:avito @ads
 include:baidu @ads

--- a/data/category-ads-all
+++ b/data/category-ads-all
@@ -3,6 +3,7 @@ include:category-ads
 
 include:addthis
 include:adjust
+include:amplitude
 include:clearbit
 include:growingio
 include:ogury

--- a/data/category-ads-all
+++ b/data/category-ads-all
@@ -3,7 +3,6 @@ include:category-ads
 
 include:addthis
 include:adjust
-include:amplitude
 include:clearbit
 include:growingio
 include:ogury

--- a/data/unity
+++ b/data/unity
@@ -4,7 +4,6 @@ unity3d.com
 # Ads/tracking
 # https://github.com/v2fly/domain-list-community/pull/3716
 analytics.cloud.unity3d.com @ads
-api2.amplitude.com @ads
 config.uca.cloud.unity3d.com @ads
 cdp.cloud.unity3d.com @ads
 prd-lender.cdp.internal.unity3d.com @ads


### PR DESCRIPTION
## Summary

Add `data/amplitude` with a comprehensive list of domains operated by [Amplitude](https://amplitude.com), verified against the official documentation (https://amplitude.com/docs). Domains are tagged `@ads` only when they serve analytics/tracking purposes (event ingestion, session replay capture, engagement delivery, SDK distribution); product dashboards, management APIs and utility endpoints are left untagged.

Also includes two related cleanups:
- `data/category-ads-all`: add `include:amplitude` so the `@ads` entries are picked up.
- `data/unity`: remove the duplicate `api2.amplitude.com @ads`, now covered by `data/amplitude`.

## Domains tagged `@ads`

| Domain | Purpose | Reference |
| --- | --- | --- |
| `api.amplitude.com`, `api2.amplitude.com`, `api.eu.amplitude.com` | Event ingestion endpoints (HTTP API v2 / Batch upload), the primary tracking hosts used by all SDKs | [HTTP V2 API](https://amplitude.com/docs/apis/analytics/http-v2), [Batch Event Upload API](https://amplitude.com/docs/apis/analytics/batch-event-upload) |
| `regionconfig.amplitude.com`, `regionconfig.eu.amplitude.com` | Dynamic configuration endpoints used by SDKs to resolve the best ingestion server; declared by Amplitude itself under `NSPrivacyTrackingDomains` in the iOS privacy manifest | [iOS SDK](https://amplitude.com/docs/sdks/analytics/ios/ios-sdk), [Dynamic Configuration](https://amplitude.com/docs/sdks/dynamic-configuration) |
| `api-sr.*`, `sr-client-cfg.*`, `api-secure.*` (US + EU) | Session Replay capture, remote configuration and data upload endpoints | [Session Replay SDK](https://amplitude.com/docs/sdks/session-replay/session-replay-standalone-sdk) |
| `gs.*`, `engagement-static.*`, `assistant-api.*` (US + EU) | Guides & Surveys content delivery and interaction tracking | [Proxy requests to Guides and Surveys](https://amplitude.com/docs/guides-and-surveys/proxy) |
| `cdn.amplitude.com`, `cdn.eu.amplitude.com` | CDN distributing the analytics/experiment SDK scripts to end-user browsers | [Browser SDK](https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2) |
| `lab.amplitude.com`, `lab.eu.amplitude.com` | Covers all Experiment evaluation endpoints (`api.lab`, `flag.lab`, `stream.lab`, `cohort.lab`, `cohort-v2.lab`) via subdomain matching | [Experiment Evaluation API](https://amplitude.com/docs/apis/experiment/experiment-evaluation-api) |

## Domains left untagged

Product dashboards, management/admin APIs and non-tracking utility hosts:

- `amplitude.com`, `app.*`, `eu.amplitude.com`, `recommend.amplitude.com` — web app, login and marketing pages
- `analytics.amplitude.com`, `analytics.eu.amplitude.com` — Analytics web app and Dashboard REST API ([docs](https://amplitude.com/docs/apis/analytics/dashboard-rest))
- `core.*` — SCIM API ([docs](https://amplitude.com/docs/apis/analytics/scim))
- `data-api.*` — Lookup Table API ([docs](https://amplitude.com/docs/apis/analytics/lookup-table-2))
- `privacy.*` — User Privacy API ([docs](https://amplitude.com/docs/apis/analytics/user-privacy-v2))
- `profile-api.*` — User Profile API ([docs](https://amplitude.com/docs/apis/analytics/user-profile))
- `experiment.*` — Experiment management API/UI ([docs](https://amplitude.com/docs/apis/experiment))
- `mcp.*` — Amplitude MCP server ([docs](https://amplitude.com/docs/analytics/amplitude-mcp))
- `data.*` — Amplitude Data UI/API ([docs](https://amplitude.com/docs/data))

## Verification

All entries were cross-checked against Amplitude's official documentation (API references, SDK configuration defaults, CSP allowlist guides and the iOS privacy manifest). 
