### PR TITLE
`remnawave`: add remna.st

### DIFF
--- a/data/remnawave
+++ b/data/remnawave
@@ -1,3 +1,4 @@
 docs.rw
 log.rw
+remna.st
 try.rw


### PR DESCRIPTION
[remna.st](https://remna.st)  is the legacy domain of the Remnawave project.
It now only redirects:
- [remna.st](https://remna.st) -> [docs.rw](https://docs.rw)
- [hub.remna.st](https://hub.remna.st) -> [f.docs.rw](https://f.docs.rw)
- [i18n.remna.st](https://i18n.remna.st) -> [crowdin.com/project/remnawave](https://crowdin.com/project/remnawave)