### PR TITLE
`category-ai-cn`: add more domains

### DIFF
--- a/data/category-ai-cn
+++ b/data/category-ai-cn
@@ -54,6 +54,8 @@ tiangong.cn
 # 智谱
 bigmodel.cn
 chatglm.cn
+chatglm.site
+space-z.ai
 z.ai
 zhipuai.cn
 zhipucn.com


### PR DESCRIPTION
When visiting [chat.z.ai,](https://chat.z.ai) requests are also made to [chatglm.site](https://chatglm.site) and [space-z.ai](https://space-z.ai). Adding both domains to the Zhipu (智谱) group.