### PR TITLE
Add Freebuff domain list

### DIFF
--- a/data/category-dev
+++ b/data/category-dev
@@ -20,6 +20,7 @@ include:flatpak
 include:flutter
 include:fontawesome
 include:framer
+include:freebuff
 include:gemfury
 include:gitbook
 include:github

--- a/data/freebuff
+++ b/data/freebuff
@@ -1,0 +1,9 @@
+# Freebuff - https://freebuff.com/
+# Source: https://github.com/CodebuffAI/freebuff
+
+codebuff.com
+freebuff.com
+
+# Direct client-side advertising and telemetry endpoints
+full:us.i.posthog.com @ads
+zeroclick.dev @ads

--- a/data/freebuff
+++ b/data/freebuff
@@ -3,7 +3,3 @@
 
 codebuff.com
 freebuff.com
-
-# Direct client-side advertising and telemetry endpoints
-full:us.i.posthog.com @ads
-zeroclick.dev @ads


### PR DESCRIPTION
Add a domain list for [[Freebuff](https://freebuff.com/)](https://freebuff.com/), an open-source AI coding agent maintained in the [[CodebuffAI/freebuff](https://github.com/CodebuffAI/freebuff)](https://github.com/CodebuffAI/freebuff) repository.

This PR adds the primary domains used directly by the Freebuff client:

* `freebuff.com` — Freebuff website and authentication
* `codebuff.com` — backend API and model requests
* `us.i.posthog.com` — client-side telemetry
* `zeroclick.dev` — direct client-side advertising/impression endpoint

Telemetry and advertising domains are marked with the `@ads` attribute where applicable.

Freebuff is also included in `category-dev` because it is a developer/coding tool.

Upstream model-provider domains such as OpenRouter are intentionally not included because Freebuff routes model requests through the Codebuff backend instead of connecting to those providers directly from the client.

Sources:

* https://freebuff.com/
* https://github.com/CodebuffAI/freebuff

Validation:

* `go run ./` passes
* `go test ./...` passes