### PR TITLE
Add 360scdn.com to Qihoo360 data

### DIFF
--- a/data/qihoo360
+++ b/data/qihoo360
@@ -21,6 +21,7 @@ yun
 360panyun.cn
 360qhcdn.com
 360safe.com
+360scdn.com
 360shouji.com
 360so.com
 360sou.cn


### PR DESCRIPTION
## Summary

Add `360scdn.com` to `data/qihoo360`.

## Domain ownership

| Item | Value |
| --- | --- |
| Domain | `360scdn.com` |
| ICP license number | 京ICP备2020049243号-3 (base license: 京ICP备2020049243号) |
| License holder | 北京奇元科技有限公司 |
| Parent company | 北京三六零数智科技有限公司 (100% wholly-owned subsidiary, verified via 企查查 / QCC) |

## Rationale

`360scdn.com` is a CDN domain operated by 北京奇元科技有限公司. According to [企查查](https://www.qcc.com) (QCC), this entity is a **100% wholly-owned subsidiary** of 北京三六零数智科技有限公司, which is part of the 360 (Qihoo) group. The domain therefore belongs to 360 and is added to `data/qihoo360`.

The entry is placed in alphabetical order, between `360safe.com` and `360shouji.com`, and left untagged since it is a CDN host rather than an ads/tracking endpoint.

## Changes

- `data/qihoo360`: add `360scdn.com` (1 line)
