### PR TITLE
Add new Firefox portal detection domain

### DIFF
--- a/data/connectivity-check
+++ b/data/connectivity-check
@@ -15,6 +15,7 @@ network-test.debian.org
 
 # Firefox
 detectportal.firefox.com
+firefox-portal-detection.com
 
 # GNOME
 full:nmcheck.gnome.org


### PR DESCRIPTION
<!--

Thanks for your contribution!

Please check the following items: (not mandatory)

- Adjacent rules should be sorted alphabetically
- It's not encouraged to create new list/file containing too few (one or two) rules
- Newly added list should be included in relevant categories if possible
- Subdomains are unnecessary as they are overridden by the parent domain. e.g. `[domain:]example.com` overrides `[domain:]app.example.com`
- Description for your changes is welcome (why the change is necessary, data source of added domains, potential impacts, etc.)

-->

Firefox 155 adds a new portal detection domain, please add it to the connection check list.