### PR TITLE
feat(category-speedtest): add librespeed.org

### DIFF
--- a/data/category-speedtest
+++ b/data/category-speedtest
@@ -4,6 +4,7 @@ include:openspeedtest
 cnspeedtest.cn @cn
 fast.com
 fastspeedtest.com
+librespeed.org
 linkmeter.net
 measurementlab.net
 meter.net


### PR DESCRIPTION
LibreSpeed is a self-hosted HTML5 speed test. Self-hosted instances cannot be enumerated, but `librespeed.org` is the project's own domain and the public instance its README links to as "Take a speed test" — the one address everybody reaches first.

It is the homepage of https://github.com/librespeed/speedtest.
