### PR TITLE
feat(category-ip-geo-detect): add iplogger.org, iplogger.com

### DIFF
--- a/data/category-ip-geo-detect
+++ b/data/category-ip-geo-detect
@@ -98,6 +98,8 @@ iplocate.io
 iplocation.com
 iplocation.io
 iplocation.net
+iplogger.com
+iplogger.org
 iplookup.it
 ipme.co
 ipme.in


### PR DESCRIPTION
IPLogger hands out short links whose purpose is to report the visitor's address and approximate location back to whoever created the link. That is the capability this list already covers, reached from the other side: instead of a client asking a service where it came from, a link asks on the client's behalf.

`iplogger.com` answers with a 301 to `iplogger.org`.
