### PR TITLE
Update Firebase. app distribution domains

### DIFF
--- a/data/firebase
+++ b/data/firebase
@@ -4,11 +4,15 @@ firebase.io
 firebaseapp.com
 firebaseio.com
 
+full:appdistribution.firebase.dev
+full:appdistribution.firebase.google.com
 full:crashlyticsreports-pa.googleapis.com @cn
 full:firebase-settings.crashlytics.com @cn
 full:firebase.google.com
 full:firebase.googleapis.com
 full:firebaseappcheck.googleapis.com
+full:firebaseappdistribution.googleapis.com
+full:firebaseapptesters.googleapis.com
 full:firebasedynamiclinks-ipv4.googleapis.com
 full:firebasedynamiclinks-ipv6.googleapis.com
 full:firebasedynamiclinks.googleapis.com


### PR DESCRIPTION
Add missing Firebase App Distribution domains:

- appdistribution.firebase.dev - tester invitations and registration
- appdistribution.firebase.google.com - tester web interface
- firebaseappdistribution.googleapis.com - App Distribution API and release binary downloads
- firebaseapptesters.googleapis.com - download endpoint used by the Android Firebase App Tester

The Android App Tester download log confirms requests to
firebaseapptesters.googleapis.com. These domains are not covered by
the existing entries in data/firebase.

References:
https://firebase.google.com/docs/reference/app-distribution/rest
https://firebase.google.com/docs/app-distribution/get-set-up-as-a-tester
https://github.com/firebase/firebase-ios-sdk/issues/10772