### PR TITLE
Add nodeseek.org to nodeseek domain list

### DIFF
--- a/data/nodeseek
+++ b/data/nodeseek
@@ -4,3 +4,4 @@ nodeget.com
 nodeimage.com
 nodequality.com
 nodeseek.com
+nodeseek.org


### PR DESCRIPTION
Found this domain while using the NodeSeek forum. The site loads a tracking/analytics script from stat.nodeseek.org (script.js), which then reports data via stat.nodeseek.org/api/send — suggesting nodeseek.org is used as a secondary domain for analytics purposes alongside nodeseek.com. 