### PR TITLE
feat: add steam domains

### DIFF
--- a/data/steam
+++ b/data/steam
@@ -73,7 +73,8 @@ wmsjsteam.com @cn
 client-update.queniuqe.com @cn
 
 # 新流云
-dl.steam.clngaa.com @cn
+dl.file.cyngaa.com @cn
+steam.clngaa.com @cn
 
 # 白山云
 st.dl.bscstorage.net @cn
@@ -86,11 +87,17 @@ steamstatic.com.8686c.com @cn
 
 # 阿里云
 full:alibaba.cdn.steampipe.steamcontent.com @cn
+full:files.steam.nsclouds.cn @cn
 full:lv.queniujq.cn @cn
+full:steamcloud-hkg.oss-accelerate.aliyuncs.com @cn
+full:steamcloud-sgp.oss-accelerate.aliyuncs.com @cn
 full:xz.pphimalayanrt.com @cn
+full:xz.sycontroller.com @cn
+akk.gdtstream.com @cn
 
 # 蒸汽中国
 steamchina.com @cn
 
 # 数云科技
 gstore.val.manlaxy.com @cn
+gstore.val.smogfly.com @cn


### PR DESCRIPTION
补充国内可直连的steam下载域名

- 由于收集到了 `dl1.steam.clngaa.com`，考虑到可能会出现 `dl2`、`dl3` 等开头的域名，所以 `dl.steam.clngaa.com` 更改为 `steam.clngaa.com`
- 所有域名均使用国内DNS解析测试过，连通性良好

以下给出部分下载时的连接截图
<img width="2036" height="414" alt="image" src="https://github.com/user-attachments/assets/cc04646c-8fe2-4a31-bd7a-f5cd146dff1b" />
<img width="1511" height="323" alt="image" src="https://github.com/user-attachments/assets/ddc38602-7ba6-4786-a210-aab70ab06aed" />
<img width="1545" height="692" alt="image" src="https://github.com/user-attachments/assets/1ddfa6b7-57c0-40b9-ad1b-91c18d1d39b0" />
